### PR TITLE
Add tests to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
+      - run: npm test
       - run: npm run cf-typegen
       - name: Check generated types are committed
         run: git diff --exit-code

--- a/src/clients/gemini.test.ts
+++ b/src/clients/gemini.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGenerateContent = vi.fn();
+
+vi.mock('@google/genai', () => ({
+	GoogleGenAI: vi.fn().mockImplementation(() => ({
+		models: {
+			generateContent: mockGenerateContent,
+		},
+	})),
+}));
+
+import { GeminiClient, createGeminiClient } from './gemini';
+
+describe('GeminiClient', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('constructor', () => {
+		it('initializes with empty history by default', () => {
+			const client = new GeminiClient('test-api-key');
+			expect(client.getHistory()).toEqual([]);
+		});
+
+		it('initializes with provided history', () => {
+			const history = [{ role: 'user', text: 'previous question' }];
+			const client = new GeminiClient('test-api-key', history);
+			expect(client.getHistory()).toEqual(history);
+		});
+	});
+
+	describe('ask', () => {
+		it('returns generated response text', async () => {
+			mockGenerateContent.mockResolvedValue({
+				candidates: [
+					{
+						content: {
+							parts: [{ text: 'AI response' }],
+						},
+					},
+				],
+			});
+
+			const client = new GeminiClient('test-api-key');
+			const result = await client.ask('question', 'sheet data', 'description');
+
+			expect(result).toBe('AI response');
+		});
+
+		it('adds user question and model response to history', async () => {
+			mockGenerateContent.mockResolvedValue({
+				candidates: [
+					{
+						content: {
+							parts: [{ text: 'AI response' }],
+						},
+					},
+				],
+			});
+
+			const client = new GeminiClient('test-api-key');
+			await client.ask('test question', 'sheet', 'desc');
+
+			const history = client.getHistory();
+			expect(history).toHaveLength(2);
+			expect(history[0].role).toBe('user');
+			expect(history[0].text).toBe('質問: test question');
+			expect(history[1].role).toBe('model');
+			expect(history[1].text).toBe('AI response');
+		});
+
+		it('throws error when response has no candidates', async () => {
+			mockGenerateContent.mockResolvedValue({
+				candidates: null,
+			});
+
+			const client = new GeminiClient('test-api-key');
+
+			await expect(client.ask('q', 's', 'd')).rejects.toThrow('Invalid response from Gemini API');
+		});
+
+		it('throws error when response has empty candidates array', async () => {
+			mockGenerateContent.mockResolvedValue({
+				candidates: [],
+			});
+
+			const client = new GeminiClient('test-api-key');
+
+			await expect(client.ask('q', 's', 'd')).rejects.toThrow('Invalid response from Gemini API');
+		});
+
+		it('throws error when response has no text', async () => {
+			mockGenerateContent.mockResolvedValue({
+				candidates: [
+					{
+						content: {
+							parts: [{ text: null }],
+						},
+					},
+				],
+			});
+
+			const client = new GeminiClient('test-api-key');
+
+			await expect(client.ask('q', 's', 'd')).rejects.toThrow('No text response from Gemini API');
+		});
+
+		it('includes conversation history in subsequent calls', async () => {
+			mockGenerateContent.mockResolvedValue({
+				candidates: [
+					{
+						content: {
+							parts: [{ text: 'response' }],
+						},
+					},
+				],
+			});
+
+			const history = [{ role: 'user', text: 'previous' }];
+			const client = new GeminiClient('test-api-key', history);
+
+			await client.ask('new question', 'sheet', 'desc');
+
+			expect(mockGenerateContent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					contents: expect.stringContaining('previous'),
+				})
+			);
+		});
+	});
+
+	describe('clearHistory', () => {
+		it('clears all history', () => {
+			const client = new GeminiClient('test-api-key', [{ role: 'user', text: 'test' }]);
+			client.clearHistory();
+			expect(client.getHistory()).toEqual([]);
+		});
+	});
+
+	describe('createGeminiClient', () => {
+		it('creates a new GeminiClient instance', () => {
+			const client = createGeminiClient('test-api-key');
+			expect(client).toBeInstanceOf(GeminiClient);
+		});
+
+		it('creates client with initial history', () => {
+			const history = [{ role: 'user', text: 'hello' }];
+			const client = createGeminiClient('test-api-key', history);
+			expect(client.getHistory()).toEqual(history);
+		});
+	});
+});

--- a/src/clients/kv.test.ts
+++ b/src/clients/kv.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { KV, createKV } from './kv';
+
+const createMockKVNamespace = () =>
+	({
+		get: vi.fn(),
+		put: vi.fn(),
+		delete: vi.fn(),
+		list: vi.fn(),
+		getWithMetadata: vi.fn(),
+	}) as unknown as KVNamespace;
+
+describe('KV class', () => {
+	let mockKV: KVNamespace;
+	let kv: KV;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockKV = createMockKVNamespace();
+		kv = new KV(mockKV);
+	});
+
+	describe('saveHistory', () => {
+		it('saves history with current timestamp', async () => {
+			const history = [{ role: 'user', text: 'hello' }];
+
+			await kv.saveHistory(history);
+
+			expect(mockKV.put).toHaveBeenCalledWith('chat_history', expect.stringContaining('"role":"user"'));
+			expect(mockKV.put).toHaveBeenCalledWith('chat_history', expect.stringContaining('"text":"hello"'));
+			expect(mockKV.put).toHaveBeenCalledWith('chat_history', expect.stringContaining('"timestamp":'));
+		});
+	});
+
+	describe('getHistory', () => {
+		it('returns empty array when no history exists', async () => {
+			(mockKV.get as Mock).mockResolvedValue(null);
+
+			const result = await kv.getHistory();
+
+			expect(result).toEqual([]);
+		});
+
+		it('filters out history older than 5 minutes', async () => {
+			const oldTimestamp = Date.now() - 6 * 60 * 1000; // 6 minutes ago
+			const recentTimestamp = Date.now() - 2 * 60 * 1000; // 2 minutes ago
+
+			(mockKV.get as Mock).mockResolvedValue(
+				JSON.stringify([
+					{ role: 'user', text: 'old', timestamp: oldTimestamp },
+					{ role: 'user', text: 'recent', timestamp: recentTimestamp },
+				])
+			);
+
+			const result = await kv.getHistory();
+
+			expect(result).toHaveLength(1);
+			expect(result[0].text).toBe('recent');
+		});
+
+		it('returns history within 5-minute window', async () => {
+			const recentTimestamp = Date.now() - 2 * 60 * 1000; // 2 minutes ago
+
+			(mockKV.get as Mock).mockResolvedValue(
+				JSON.stringify([{ role: 'model', text: 'response', timestamp: recentTimestamp }])
+			);
+
+			const result = await kv.getHistory();
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual({ role: 'model', text: 'response' });
+		});
+	});
+
+	describe('getCache', () => {
+		it('returns null when no cache exists', async () => {
+			(mockKV.get as Mock).mockResolvedValue(null);
+
+			const result = await kv.getCache();
+
+			expect(result).toBeNull();
+		});
+
+		it('returns null when cache is expired (older than 5 minutes)', async () => {
+			const expiredCache = {
+				time: Date.now() - 6 * 60 * 1000,
+				sheetInfo: 'data',
+				description: 'desc',
+			};
+			(mockKV.get as Mock).mockResolvedValue(expiredCache);
+
+			const result = await kv.getCache();
+
+			expect(result).toBeNull();
+		});
+
+		it('returns cached data when within 5 minutes', async () => {
+			const validCache = {
+				time: Date.now() - 2 * 60 * 1000,
+				sheetInfo: 'sheet data',
+				description: 'description',
+			};
+			(mockKV.get as Mock).mockResolvedValue(validCache);
+
+			const result = await kv.getCache();
+
+			expect(result).toEqual({
+				sheetInfo: 'sheet data',
+				description: 'description',
+				time: validCache.time,
+			});
+		});
+	});
+
+	describe('saveCache', () => {
+		it('saves cache with current timestamp', async () => {
+			await kv.saveCache('sheet info', 'description');
+
+			expect(mockKV.put).toHaveBeenCalledWith('sheet_info', expect.stringContaining('"sheetInfo":"sheet info"'));
+			expect(mockKV.put).toHaveBeenCalledWith('sheet_info', expect.stringContaining('"description":"description"'));
+			expect(mockKV.put).toHaveBeenCalledWith('sheet_info', expect.stringContaining('"time":'));
+		});
+	});
+
+	describe('createKV', () => {
+		it('creates a new KV instance', () => {
+			const instance = createKV(mockKV);
+			expect(instance).toBeInstanceOf(KV);
+		});
+	});
+});

--- a/src/handlers/answerQuestion.test.ts
+++ b/src/handlers/answerQuestion.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Bindings } from '../types';
+
+const mockKVInstance = {
+	getCache: vi.fn(),
+	getHistory: vi.fn(),
+	saveCache: vi.fn(),
+	saveHistory: vi.fn(),
+};
+
+const mockGeminiInstance = {
+	ask: vi.fn(),
+	getHistory: vi.fn(),
+};
+
+vi.mock('../clients/kv', () => ({
+	createKV: vi.fn(() => mockKVInstance),
+}));
+
+vi.mock('../clients/gemini', () => ({
+	createGeminiClient: vi.fn(() => mockGeminiInstance),
+}));
+
+vi.mock('../clients/spreadSheet', () => ({
+	getSheetInfo: vi.fn(),
+	getSheetDescription: vi.fn(),
+}));
+
+import { answerQuestion } from './answerQuestion';
+import { createKV } from '../clients/kv';
+import { createGeminiClient } from '../clients/gemini';
+import { getSheetInfo, getSheetDescription } from '../clients/spreadSheet';
+
+const mockEnv: Bindings = {
+	DISCORD_TOKEN: 'test-token',
+	DISCORD_PUBLIC_KEY: 'test-public-key',
+	DISCORD_APPLICATION_ID: 'test-app-id',
+	DISCORD_TEST_GUILD_ID: 'test-guild-id',
+	GEMINI_API_KEY: 'test-gemini-key',
+	GOOGLE_SERVICE_ACCOUNT_EMAIL: 'test@example.com',
+	GOOGLE_PRIVATE_KEY: 'test-key',
+	GOOGLE_SERVICE_ACCOUNT: '{"type":"service_account"}',
+	sushanshan_bot: {} as KVNamespace,
+};
+
+describe('answerQuestion', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockKVInstance.getHistory.mockResolvedValue([]);
+		mockGeminiInstance.ask.mockResolvedValue('AI response');
+		mockGeminiInstance.getHistory.mockReturnValue([]);
+	});
+
+	it('uses cached data when available', async () => {
+		mockKVInstance.getCache.mockResolvedValue({
+			sheetInfo: 'cached sheet',
+			description: 'cached desc',
+		});
+
+		await answerQuestion('test question', mockEnv);
+
+		expect(getSheetInfo).not.toHaveBeenCalled();
+		expect(getSheetDescription).not.toHaveBeenCalled();
+	});
+
+	it('fetches sheet data when cache is empty', async () => {
+		mockKVInstance.getCache.mockResolvedValue(null);
+		vi.mocked(getSheetInfo).mockResolvedValue('new sheet');
+		vi.mocked(getSheetDescription).mockResolvedValue('new desc');
+
+		await answerQuestion('test question', mockEnv);
+
+		expect(getSheetInfo).toHaveBeenCalledWith(mockEnv.GOOGLE_SERVICE_ACCOUNT);
+		expect(getSheetDescription).toHaveBeenCalledWith(mockEnv.GOOGLE_SERVICE_ACCOUNT);
+	});
+
+	it('saves cache when fetching fresh data', async () => {
+		mockKVInstance.getCache.mockResolvedValue(null);
+		vi.mocked(getSheetInfo).mockResolvedValue('fresh sheet');
+		vi.mocked(getSheetDescription).mockResolvedValue('fresh desc');
+
+		await answerQuestion('test question', mockEnv);
+
+		expect(mockKVInstance.saveCache).toHaveBeenCalledWith('fresh sheet', 'fresh desc');
+	});
+
+	it('does not save cache when using cached data', async () => {
+		mockKVInstance.getCache.mockResolvedValue({
+			sheetInfo: 'cached sheet',
+			description: 'cached desc',
+		});
+
+		await answerQuestion('test question', mockEnv);
+
+		expect(mockKVInstance.saveCache).not.toHaveBeenCalled();
+	});
+
+	it('saves updated history after getting response', async () => {
+		const updatedHistory = [
+			{ role: 'user', text: '質問: test' },
+			{ role: 'model', text: 'AI response' },
+		];
+		mockKVInstance.getCache.mockResolvedValue({
+			sheetInfo: 'sheet',
+			description: 'desc',
+		});
+		mockGeminiInstance.getHistory.mockReturnValue(updatedHistory);
+
+		await answerQuestion('test question', mockEnv);
+
+		expect(mockKVInstance.saveHistory).toHaveBeenCalledWith(updatedHistory);
+	});
+
+	it('passes existing history to GeminiClient', async () => {
+		const existingHistory = [{ role: 'user', text: 'old question' }];
+		mockKVInstance.getCache.mockResolvedValue({
+			sheetInfo: 'sheet',
+			description: 'desc',
+		});
+		mockKVInstance.getHistory.mockResolvedValue(existingHistory);
+
+		await answerQuestion('test question', mockEnv);
+
+		expect(createGeminiClient).toHaveBeenCalledWith(mockEnv.GEMINI_API_KEY, existingHistory);
+	});
+
+	it('returns the response from Gemini', async () => {
+		mockKVInstance.getCache.mockResolvedValue({
+			sheetInfo: 'sheet',
+			description: 'desc',
+		});
+		mockGeminiInstance.ask.mockResolvedValue('Gemini answer');
+
+		const result = await answerQuestion('test question', mockEnv);
+
+		expect(result).toBe('Gemini answer');
+	});
+
+	it('calls Gemini ask with correct parameters', async () => {
+		mockKVInstance.getCache.mockResolvedValue({
+			sheetInfo: 'sheet data',
+			description: 'sheet description',
+		});
+
+		await answerQuestion('user question', mockEnv);
+
+		expect(mockGeminiInstance.ask).toHaveBeenCalledWith('user question', 'sheet data', 'sheet description');
+	});
+});

--- a/src/responses/errorResponse.test.ts
+++ b/src/responses/errorResponse.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('discord-api-types/v10', () => ({
+	InteractionResponseType: {
+		ChannelMessageWithSource: 4,
+	},
+}));
+
+import { errorResponse } from './errorResponse';
+
+describe('errorResponse', () => {
+	it('returns ChannelMessageWithSource type', () => {
+		const result = errorResponse('test error');
+		// InteractionResponseType.ChannelMessageWithSource = 4
+		expect(result.type).toBe(4);
+	});
+
+	it('includes error header content', () => {
+		const result = errorResponse('test error');
+		expect(result.data.content).toBe('🚨 エラーが発生しました');
+	});
+
+	it('includes error message in embed description', () => {
+		const result = errorResponse('Database connection failed');
+		expect(result.data.embeds?.[0].description).toBe('Database connection failed');
+	});
+
+	it('uses red color (0xff0000) for error embed', () => {
+		const result = errorResponse('any error');
+		expect(result.data.embeds?.[0].color).toBe(0xff0000);
+	});
+
+	it('handles empty error message', () => {
+		const result = errorResponse('');
+		expect(result.data.embeds?.[0].description).toBe('');
+	});
+});


### PR DESCRIPTION
## Summary
- CIワークフローに `npm test` ステップを追加
- 4つのテストファイルを追加（33テストケース）
  - errorResponse: 5テスト
  - KV client: 9テスト
  - Gemini client: 11テスト
  - answerQuestion handler: 8テスト

## Test plan
- [x] `npm test` がローカルで全テストパス
- [ ] CIでテストが実行されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)