### PR TITLE
Add build verification and split CI into separate jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,14 +17,34 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm test
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
       - name: Build verification (dry-run)
         run: npx wrangler deploy --dry-run --minify src/index.ts
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
       - run: npm run cf-typegen
       - name: Check generated types are committed
         run: git diff --exit-code
 
   deploy:
-    needs: build
+    needs: [test, build, typecheck]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- CIにwrangler deploy --dry-runを追加し、PRの段階でビルドが成功するか確認できるようにした
- test, build, typecheckを別々のjobに分離し、失敗箇所を明確化
- 3つのjobは並列実行され、すべて成功した場合のみdeployが実行される

## Test plan
- [ ] CIが正常に動作することを確認
- [ ] dry-runステップが成功することを確認
- [ ] 各jobが並列実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)