### PR TITLE
Disable automatic Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,8 @@ on:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.user.login == 'henzai'
+    if: false # Temporarily disabled
+    # if: github.event.pull_request.user.login == 'henzai'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- PRの自動レビューワークフローを一時的に無効化

## Changes
- `.github/workflows/claude-code-review.yml`の`if`条件を`false`に設定
- 元の条件はコメントアウトして保持（再開時に容易に戻せるように）

🤖 Generated with [Claude Code](https://claude.com/claude-code)