### PR TITLE
Fix: KVキャッシュのJSONパースエラーを修正

### DIFF
--- a/src/clients/kv.ts
+++ b/src/clients/kv.ts
@@ -82,7 +82,7 @@ export class KV {
 
 	async getCache(): Promise<Omit<SheetInfo, 'time'> | null> {
 		try {
-			const cachedData = await this.kv.get<SheetInfo>(SHEET_INFO);
+			const cachedData = await this.kv.get<SheetInfo>(SHEET_INFO, "json");
 			if (!cachedData) return null;
 
 			// Validate cache structure


### PR DESCRIPTION
## 概要
- Cloudflareログに出力されていた「Invalid cache data structure, ignoring cache」エラーを修正

## 問題
`kv.get<SheetInfo>(SHEET_INFO)`がJSON文字列を返すのに、オブジェクトとして扱おうとしていたため、バリデーションチェックが失敗していました。

## 解決策
`kv.get()`の第2引数に`"json"`を追加し、自動的にJSONをパースするようにしました。

## 変更内容
- [src/clients/kv.ts](src/clients/kv.ts#L85): `kv.get()`に`"json"`パラメータを追加

## テスト方法
- [ ] デプロイ後に`/ask`コマンドを実行
- [ ] Cloudflareログでエラーが出ないことを確認
- [ ] 5分以内に2回目のリクエストでキャッシュが機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)