### PR TITLE
Fix waitUntil() timeout on cache miss

### DIFF
--- a/src/clients/gemini.ts
+++ b/src/clients/gemini.ts
@@ -23,6 +23,8 @@ ${historyText ? `会話履歴:\n${historyText}\n\n` : ''}質問: ${input}`;
 			let result;
 			try {
 				// Add retry logic with exponential backoff
+				console.log(`[INFO] Gemini API request starting`);
+				const startTime = Date.now();
 				result = await withRetry(
 					async () => {
 						return await this.client.models.generateContent({
@@ -32,9 +34,9 @@ ${historyText ? `会話履歴:\n${historyText}\n\n` : ''}質問: ${input}`;
 						});
 					},
 					{
-						maxAttempts: 3,
-						initialDelayMs: 1000,
-						maxDelayMs: 8000,
+						maxAttempts: 2,
+						initialDelayMs: 500,
+						maxDelayMs: 2000,
 					},
 					// Only retry on transient errors
 					(error) => {
@@ -50,6 +52,7 @@ ${historyText ? `会話履歴:\n${historyText}\n\n` : ''}質問: ${input}`;
 						);
 					}
 				);
+				console.log(`[INFO] Gemini API completed in ${Date.now() - startTime}ms`);
 			} catch (error) {
 				console.error('Gemini API request failed:', error);
 

--- a/src/handlers/answerQuestion.ts
+++ b/src/handlers/answerQuestion.ts
@@ -7,7 +7,7 @@ import { logger } from '../utils/logger';
 
 // Constants
 const SHEETS_TIMEOUT_MS = 10000; // 10 seconds
-const GEMINI_TIMEOUT_MS = 30000; // 30 seconds (Gemini can be slow)
+const GEMINI_TIMEOUT_MS = 25000; // 25 seconds - leave margin for other operations within waitUntil() 30s limit
 
 export async function answerQuestion(message: string, env: Bindings): Promise<string> {
 	return await logger.trackTiming(


### PR DESCRIPTION
## Summary
- Gemini APIタイムアウトを30秒→25秒に短縮し、waitUntil()の30秒制限内で他の処理（KV保存、Webhook送信）の時間を確保
- リトライ設定を調整（3回→2回、遅延1000ms/8000ms→500ms/2000ms）して累積時間を削減
- Gemini API呼び出しの計測ログを追加してデバッグを容易に

## Test plan
- [ ] KVキャッシュ期限切れ後に `/ask` コマンドを実行
- [ ] Cloudflare Workersログで `[INFO] Gemini API completed in XXXms` を確認
- [ ] `waitUntil() tasks did not complete` エラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)