### PR TITLE
Grant write permissions to Claude Code Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && github.event.issue.user.login == 'henzai')
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
- Claude Code Action の permissions を `read` → `write` に変更
  - `contents: write` — ブランチへのコミット・プッシュを許可
  - `pull-requests: write` — PRへのコメント投稿を許可
  - `issues: write` — Issueへのコメント投稿を許可
- PR #41 で `@claude` にCI修正を依頼した際、ファイル変更・コミットまではできたがプッシュ権限がなく反映できなかった問題を解決

## Test plan
- [ ] マージ後、任意のPRで `@claude` にファイル変更を依頼し、コミット＆プッシュまで完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)