### PR TITLE
fix: Use PAT for Claude Code Action to trigger CI

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,7 +22,6 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
@@ -35,8 +34,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
+          github_token: ${{ secrets.PAT_TOKEN }}
           additional_permissions: |
             actions: read
 


### PR DESCRIPTION
## Summary
- Claude Code Action の push に PAT を使用するよう変更し、push 後に CI が自動トリガーされるようにした
- 不要になった `id-token: write` パーミッションを削除

## Background
`GITHUB_TOKEN` による push は GitHub の仕様で後続ワークフローをトリガーしない。PAT を使うことでこの制限を回避する。

## Test plan
- [ ] リポジトリシークレットに `PAT_TOKEN` が設定済みであること
- [ ] マージ後、PR で `@claude` にコード変更を依頼し、push 後に CI が自動で動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)