### PR TITLE
fix: Pass PAT to checkout step so git push triggers CI

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## Summary
- `actions/checkout` に PAT を渡すよう修正
- PR #59 で `github_token` に PAT を渡したが、git push は checkout が設定したクレデンシャル（デフォルトの `GITHUB_TOKEN`）を使うため CI がトリガーされなかった

## Test plan
- [ ] マージ後、PR で `@claude` にコード変更を依頼し push 後に CI が自動で動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)