### PR TITLE
refactor: KVネイティブTTLを導入し、アプリ層のキャッシュ期限管理を簡素化

### DIFF
--- a/src/clients/kv.ts
+++ b/src/clients/kv.ts
@@ -4,20 +4,16 @@ import { Logger, logger as defaultLogger } from '../utils/logger';
 const SHEET_INFO = 'sheet_info';
 const HISTORY_KEY = 'chat_history';
 
-// キャッシュの持続時間
-const CACHE_DURATION_MS = 5 * 60 * 1000; // 5分
+// キャッシュの持続時間（秒）- KVネイティブTTLで使用
+const CACHE_TTL_SECONDS = 5 * 60; // 5分
 
 // キャッシュの型
 type SheetInfo = {
-	time: number;
-	// スプレッドシートの情報
 	sheetInfo: string;
-	// スプレッドシートの説明
 	description: string;
 };
 
 type ChatHistory = {
-	timestamp: number;
 	role: string;
 	text: string;
 };
@@ -33,13 +29,14 @@ export class KV {
 
 	async saveHistory(history: { role: string; text: string }[]): Promise<void> {
 		try {
-			const now = Date.now();
-			const newHistory: ChatHistory[] = history.map((h) => ({
-				...h,
-				timestamp: now,
+			const newHistory: ChatHistory[] = history.map(({ role, text }) => ({
+				role,
+				text,
 			}));
 
-			await this.kv.put(HISTORY_KEY, JSON.stringify(newHistory));
+			await this.kv.put(HISTORY_KEY, JSON.stringify(newHistory), {
+				expirationTtl: CACHE_TTL_SECONDS,
+			});
 		} catch (error) {
 			this.log.error('Failed to save history to KV', {
 				error: error instanceof Error ? error.message : 'Unknown error',
@@ -50,55 +47,37 @@ export class KV {
 
 	async getHistory(): Promise<{ role: string; text: string }[]> {
 		try {
-			const historyStr = await this.kv.get(HISTORY_KEY);
-			if (!historyStr) return [];
+			// KVネイティブTTLにより期限切れデータは自動的にnullになる
+			const parsedHistory = await this.kv.get<ChatHistory[]>(HISTORY_KEY, "json");
+			if (!parsedHistory) return [];
 
-			let parsedHistory: ChatHistory[];
-			try {
-				parsedHistory = JSON.parse(historyStr);
-			} catch (parseError) {
-				this.log.warn('Failed to parse history JSON, returning empty array', {
-					error: parseError instanceof Error ? parseError.message : 'Unknown error',
-				});
-				return [];
-			}
-
-			// Validate array structure
 			if (!Array.isArray(parsedHistory)) {
 				this.log.warn('History data is not an array, returning empty array');
 				return [];
 			}
 
-			const fiveMinutesAgo = Date.now() - CACHE_DURATION_MS;
-
-			// 5分以内の履歴のみを返す (with validation)
 			return parsedHistory
-				.filter((h) => {
-					// Validate each history item
-					if (!h || typeof h !== 'object') return false;
-					if (typeof h.timestamp !== 'number') return false;
-					if (typeof h.role !== 'string' || typeof h.text !== 'string') return false;
-					return h.timestamp > fiveMinutesAgo;
-				})
+				.filter(
+					(h): h is ChatHistory =>
+						!!h && typeof h === 'object' && typeof h.role === 'string' && typeof h.text === 'string'
+				)
 				.map(({ role, text }) => ({ role, text }));
 		} catch (error) {
 			this.log.error('Failed to get history from KV', {
 				error: error instanceof Error ? error.message : 'Unknown error',
 			});
-			// Return empty array on error - don't fail the request
 			return [];
 		}
 	}
 
-	async getCache(): Promise<Omit<SheetInfo, 'time'> | null> {
+	async getCache(): Promise<SheetInfo | null> {
 		try {
+			// KVネイティブTTLにより期限切れデータは自動的にnullになる
 			const cachedData = await this.kv.get<SheetInfo>(SHEET_INFO, "json");
 			if (!cachedData) return null;
 
-			// Validate cache structure
 			if (
 				typeof cachedData !== 'object' ||
-				typeof cachedData.time !== 'number' ||
 				typeof cachedData.sheetInfo !== 'string' ||
 				typeof cachedData.description !== 'string'
 			) {
@@ -106,16 +85,11 @@ export class KV {
 				return null;
 			}
 
-			if (Date.now() - cachedData.time < CACHE_DURATION_MS) {
-				return cachedData;
-			}
-
-			return null;
+			return cachedData;
 		} catch (error) {
 			this.log.error('Failed to get cache from KV', {
 				error: error instanceof Error ? error.message : 'Unknown error',
 			});
-			// Return null on error - will fetch fresh data
 			return null;
 		}
 	}
@@ -123,12 +97,13 @@ export class KV {
 	async saveCache(sheetInfo: string, description: string): Promise<void> {
 		try {
 			const newCacheData: SheetInfo = {
-				time: Date.now(),
 				sheetInfo: sheetInfo,
 				description: description,
 			};
 
-			await this.kv.put(SHEET_INFO, JSON.stringify(newCacheData));
+			await this.kv.put(SHEET_INFO, JSON.stringify(newCacheData), {
+				expirationTtl: CACHE_TTL_SECONDS,
+			});
 		} catch (error) {
 			this.log.error('Failed to save cache to KV', {
 				error: error instanceof Error ? error.message : 'Unknown error',


### PR DESCRIPTION
## Summary

- KVクライアントのキャッシュ期限管理を、アプリ層での `Date.now()` 比較から Cloudflare KV ネイティブの `expirationTtl` に移行
- `SheetInfo.time` と `ChatHistory.timestamp` フィールドを削除し、型を簡素化
- `getHistory()` の JSON パースを KV の `"json"` オプションに統一（`getCache()` と同じ方式）
- filter のバリデーションを type guard で簡潔に記述

## PR #61 からの改善点

- `getHistory()` と `getCache()` で JSON パース方法が不統一だった問題を修正（KV `"json"` オプションに統一）
- `.filter()` 内の冗長な `return true` パターンを type guard で改善
- 無関係な `package-lock.json` の変更を含めない

## Test plan

- [x] `npm test` で全テスト通過（81/81）
- [x] 変更対象が `kv.ts` / `kv.test.ts` のみであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)