### PR TITLE
refactor: migrate to Biome default formatting

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,17 +8,9 @@
 	"files": {
 		"includes": ["**", "!worker-configuration.d.ts", "!.claude"]
 	},
-	"formatter": {
-		"lineWidth": 140
-	},
 	"linter": {
 		"rules": {
 			"recommended": true
-		}
-	},
-	"javascript": {
-		"formatter": {
-			"quoteStyle": "single"
 		}
 	},
 	"overrides": [

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,11 @@
 	"packageRules": [
 		{
 			"groupName": "vitest",
-			"matchPackageNames": ["/vitest/", "/@vitest//", "/@cloudflare/vitest-pool-workers/"]
+			"matchPackageNames": [
+				"/vitest/",
+				"/@vitest//",
+				"/@cloudflare/vitest-pool-workers/"
+			]
 		}
 	]
 }

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -4,13 +4,13 @@
  */
 
 const WEN_COMMAND = {
-	name: 'ask',
-	description: 'Ask 433 a question',
+	name: "ask",
+	description: "Ask 433 a question",
 	options: [
 		{
 			type: 3,
-			name: 'question',
-			description: 'The question you want to ask',
+			name: "question",
+			description: "The question you want to ask",
 			required: true,
 		},
 	],

--- a/scripts/register.js
+++ b/scripts/register.js
@@ -1,6 +1,6 @@
-const { WEN_COMMAND } = require('./commands.js');
-const dotenv = require('dotenv');
-const process = require('node:process');
+const { WEN_COMMAND } = require("./commands.js");
+const dotenv = require("dotenv");
+const process = require("node:process");
 
 /**
  * This file is meant to be run from the command line, and is not used by the
@@ -8,16 +8,18 @@ const process = require('node:process');
  * to be run once.
  */
 
-dotenv.config({ path: '.dev.vars' });
+dotenv.config({ path: ".dev.vars" });
 
 const token = process.env.DISCORD_TOKEN;
 const applicationId = process.env.DISCORD_APPLICATION_ID;
 
 if (!token) {
-	throw new Error('The DISCORD_TOKEN environment variable is required.');
+	throw new Error("The DISCORD_TOKEN environment variable is required.");
 }
 if (!applicationId) {
-	throw new Error('The DISCORD_APPLICATION_ID environment variable is required.');
+	throw new Error(
+		"The DISCORD_APPLICATION_ID environment variable is required.",
+	);
 }
 
 const registerCommands = async () => {
@@ -25,19 +27,19 @@ const registerCommands = async () => {
 
 	const response = await fetch(url, {
 		headers: {
-			'Content-Type': 'application/json',
+			"Content-Type": "application/json",
 			Authorization: `Bot ${token}`,
 		},
-		method: 'PUT',
+		method: "PUT",
 		body: JSON.stringify([WEN_COMMAND]),
 	});
 
 	if (response.ok) {
-		console.log('Registered all commands');
+		console.log("Registered all commands");
 		const data = await response.json();
 		console.log(JSON.stringify(data, null, 2));
 	} else {
-		console.error('Error registering commands');
+		console.error("Error registering commands");
 		let errorText = `Error registering commands \n ${response.url}: ${response.status} ${response.statusText}`;
 		try {
 			const error = await response.text();
@@ -45,7 +47,7 @@ const registerCommands = async () => {
 				errorText = `${errorText} \n\n ${error}`;
 			}
 		} catch (err) {
-			console.error('Error reading body from request:', err);
+			console.error("Error reading body from request:", err);
 		}
 		console.error(errorText);
 	}

--- a/src/clients/gemini.test.ts
+++ b/src/clients/gemini.test.ts
@@ -1,8 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGenerateContent = vi.fn();
 
-vi.mock('@google/genai', () => ({
+vi.mock("@google/genai", () => ({
 	GoogleGenAI: vi.fn().mockImplementation(() => ({
 		models: {
 			generateContent: mockGenerateContent,
@@ -10,87 +10,91 @@ vi.mock('@google/genai', () => ({
 	})),
 }));
 
-import { createGeminiClient, GeminiClient } from './gemini';
+import { createGeminiClient, GeminiClient } from "./gemini";
 
-describe('GeminiClient', () => {
+describe("GeminiClient", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
-	describe('constructor', () => {
-		it('initializes with empty history by default', () => {
-			const client = new GeminiClient('test-api-key');
+	describe("constructor", () => {
+		it("initializes with empty history by default", () => {
+			const client = new GeminiClient("test-api-key");
 			expect(client.getHistory()).toEqual([]);
 		});
 
-		it('initializes with provided history', () => {
-			const history = [{ role: 'user', text: 'previous question' }];
-			const client = new GeminiClient('test-api-key', history);
+		it("initializes with provided history", () => {
+			const history = [{ role: "user", text: "previous question" }];
+			const client = new GeminiClient("test-api-key", history);
 			expect(client.getHistory()).toEqual(history);
 		});
 	});
 
-	describe('ask', () => {
-		it('returns generated response text', async () => {
+	describe("ask", () => {
+		it("returns generated response text", async () => {
 			mockGenerateContent.mockResolvedValue({
 				candidates: [
 					{
 						content: {
-							parts: [{ text: 'AI response' }],
+							parts: [{ text: "AI response" }],
 						},
 					},
 				],
 			});
 
-			const client = new GeminiClient('test-api-key');
-			const result = await client.ask('question', 'sheet data', 'description');
+			const client = new GeminiClient("test-api-key");
+			const result = await client.ask("question", "sheet data", "description");
 
-			expect(result).toBe('AI response');
+			expect(result).toBe("AI response");
 		});
 
-		it('adds user question and model response to history', async () => {
+		it("adds user question and model response to history", async () => {
 			mockGenerateContent.mockResolvedValue({
 				candidates: [
 					{
 						content: {
-							parts: [{ text: 'AI response' }],
+							parts: [{ text: "AI response" }],
 						},
 					},
 				],
 			});
 
-			const client = new GeminiClient('test-api-key');
-			await client.ask('test question', 'sheet', 'desc');
+			const client = new GeminiClient("test-api-key");
+			await client.ask("test question", "sheet", "desc");
 
 			const history = client.getHistory();
 			expect(history).toHaveLength(2);
-			expect(history[0].role).toBe('user');
-			expect(history[0].text).toBe('質問: test question');
-			expect(history[1].role).toBe('model');
-			expect(history[1].text).toBe('AI response');
+			expect(history[0].role).toBe("user");
+			expect(history[0].text).toBe("質問: test question");
+			expect(history[1].role).toBe("model");
+			expect(history[1].text).toBe("AI response");
 		});
 
-		it('throws error when response has no candidates', async () => {
+		it("throws error when response has no candidates", async () => {
 			mockGenerateContent.mockResolvedValue({
 				candidates: null,
 			});
 
-			const client = new GeminiClient('test-api-key');
+			const client = new GeminiClient("test-api-key");
 
-			await expect(client.ask('q', 's', 'd')).rejects.toThrow('AIからの応答形式が不正です。');
+			await expect(client.ask("q", "s", "d")).rejects.toThrow(
+				"AIからの応答形式が不正です。",
+			);
 		});
 
-		it('throws error when response has empty candidates array', async () => {
+		it("throws error when response has empty candidates array", async () => {
 			mockGenerateContent.mockResolvedValue({
 				candidates: [],
 			});
 
-			const client = new GeminiClient('test-api-key');
+			const client = new GeminiClient("test-api-key");
 
-			await expect(client.ask('q', 's', 'd')).rejects.toThrow('AIからの応答形式が不正です。');
+			await expect(client.ask("q", "s", "d")).rejects.toThrow(
+				"AIからの応答形式が不正です。",
+			);
 		});
 
-		it('throws error when response has no text', async () => {
+		it("throws error when response has no text", async () => {
 			mockGenerateContent.mockResolvedValue({
 				candidates: [
 					{
@@ -101,52 +105,56 @@ describe('GeminiClient', () => {
 				],
 			});
 
-			const client = new GeminiClient('test-api-key');
+			const client = new GeminiClient("test-api-key");
 
-			await expect(client.ask('q', 's', 'd')).rejects.toThrow('AIから有効な応答が得られませんでした。');
+			await expect(client.ask("q", "s", "d")).rejects.toThrow(
+				"AIから有効な応答が得られませんでした。",
+			);
 		});
 
-		it('includes conversation history in subsequent calls', async () => {
+		it("includes conversation history in subsequent calls", async () => {
 			mockGenerateContent.mockResolvedValue({
 				candidates: [
 					{
 						content: {
-							parts: [{ text: 'response' }],
+							parts: [{ text: "response" }],
 						},
 					},
 				],
 			});
 
-			const history = [{ role: 'user', text: 'previous' }];
-			const client = new GeminiClient('test-api-key', history);
+			const history = [{ role: "user", text: "previous" }];
+			const client = new GeminiClient("test-api-key", history);
 
-			await client.ask('new question', 'sheet', 'desc');
+			await client.ask("new question", "sheet", "desc");
 
 			expect(mockGenerateContent).toHaveBeenCalledWith(
 				expect.objectContaining({
-					contents: expect.stringContaining('previous'),
+					contents: expect.stringContaining("previous"),
 				}),
 			);
 		});
 	});
 
-	describe('clearHistory', () => {
-		it('clears all history', () => {
-			const client = new GeminiClient('test-api-key', [{ role: 'user', text: 'test' }]);
+	describe("clearHistory", () => {
+		it("clears all history", () => {
+			const client = new GeminiClient("test-api-key", [
+				{ role: "user", text: "test" },
+			]);
 			client.clearHistory();
 			expect(client.getHistory()).toEqual([]);
 		});
 	});
 
-	describe('createGeminiClient', () => {
-		it('creates a new GeminiClient instance', () => {
-			const client = createGeminiClient('test-api-key');
+	describe("createGeminiClient", () => {
+		it("creates a new GeminiClient instance", () => {
+			const client = createGeminiClient("test-api-key");
 			expect(client).toBeInstanceOf(GeminiClient);
 		});
 
-		it('creates client with initial history', () => {
-			const history = [{ role: 'user', text: 'hello' }];
-			const client = createGeminiClient('test-api-key', history);
+		it("creates client with initial history", () => {
+			const history = [{ role: "user", text: "hello" }];
+			const client = createGeminiClient("test-api-key", history);
 			expect(client.getHistory()).toEqual(history);
 		});
 	});

--- a/src/clients/gemini.ts
+++ b/src/clients/gemini.ts
@@ -1,37 +1,47 @@
-import { type GenerateContentResponse, GoogleGenAI } from '@google/genai';
-import { logger as defaultLogger, type Logger } from '../utils/logger';
-import { withRetry } from '../utils/retry';
+import { type GenerateContentResponse, GoogleGenAI } from "@google/genai";
+import { logger as defaultLogger, type Logger } from "../utils/logger";
+import { withRetry } from "../utils/retry";
 
 export class GeminiClient {
 	private client: GoogleGenAI;
 	private history: { role: string; text: string }[];
 	private log: Logger;
 
-	constructor(apiKey: string, initialHistory: { role: string; text: string }[] = [], log?: Logger) {
+	constructor(
+		apiKey: string,
+		initialHistory: { role: string; text: string }[] = [],
+		log?: Logger,
+	) {
 		this.client = new GoogleGenAI({ apiKey });
 		this.history = initialHistory;
 		this.log = log ?? defaultLogger;
 	}
 
-	async ask(input: string, sheet: string, description: string): Promise<string> {
+	async ask(
+		input: string,
+		sheet: string,
+		description: string,
+	): Promise<string> {
 		try {
 			// Create the full prompt with context and history
 			const systemPrompt = getPrompt(sheet, description);
-			const historyText = this.history.map((h) => `${h.role}: ${h.text}`).join('\n');
+			const historyText = this.history
+				.map((h) => `${h.role}: ${h.text}`)
+				.join("\n");
 
 			const fullPrompt = `${systemPrompt}
 
-${historyText ? `会話履歴:\n${historyText}\n\n` : ''}質問: ${input}`;
+${historyText ? `会話履歴:\n${historyText}\n\n` : ""}質問: ${input}`;
 
 			let result: GenerateContentResponse;
 			try {
 				// Add retry logic with exponential backoff
-				this.log.info('Gemini API request starting');
+				this.log.info("Gemini API request starting");
 				const startTime = Date.now();
 				result = await withRetry(
 					async () => {
 						return await this.client.models.generateContent({
-							model: 'gemini-3-flash-preview',
+							model: "gemini-3-flash-preview",
 							contents: fullPrompt,
 							config: generationConfig,
 						});
@@ -46,33 +56,43 @@ ${historyText ? `会話履歴:\n${historyText}\n\n` : ''}質問: ${input}`;
 						const msg = error.message.toLowerCase();
 						// Retry rate limits, network errors, and server errors
 						return (
-							msg.includes('quota') ||
-							msg.includes('rate limit') ||
-							msg.includes('network') ||
-							msg.includes('timeout') ||
-							msg.includes('500') ||
-							msg.includes('503')
+							msg.includes("quota") ||
+							msg.includes("rate limit") ||
+							msg.includes("network") ||
+							msg.includes("timeout") ||
+							msg.includes("500") ||
+							msg.includes("503")
 						);
 					},
 					this.log,
 				);
-				this.log.info('Gemini API completed', { durationMs: Date.now() - startTime });
+				this.log.info("Gemini API completed", {
+					durationMs: Date.now() - startTime,
+				});
 			} catch (error) {
-				this.log.error('Gemini API request failed', {
-					error: error instanceof Error ? error.message : 'Unknown error',
+				this.log.error("Gemini API request failed", {
+					error: error instanceof Error ? error.message : "Unknown error",
 				});
 
 				// Check for specific error types
 				if (error instanceof Error) {
-					if (error.message.includes('quota') || error.message.includes('rate limit')) {
-						throw new Error('API使用制限に達しました。しばらく待ってから再度お試しください。');
+					if (
+						error.message.includes("quota") ||
+						error.message.includes("rate limit")
+					) {
+						throw new Error(
+							"API使用制限に達しました。しばらく待ってから再度お試しください。",
+						);
 					}
-					if (error.message.includes('invalid') || error.message.includes('API key')) {
-						throw new Error('API認証エラーが発生しました。');
+					if (
+						error.message.includes("invalid") ||
+						error.message.includes("API key")
+					) {
+						throw new Error("API認証エラーが発生しました。");
 					}
 				}
 
-				throw new Error('AI APIへのリクエストに失敗しました。');
+				throw new Error("AI APIへのリクエストに失敗しました。");
 			}
 
 			// Validate response structure
@@ -83,40 +103,43 @@ ${historyText ? `会話履歴:\n${historyText}\n\n` : ''}質問: ${input}`;
 				!result.candidates[0].content.parts ||
 				!result.candidates[0].content.parts[0]
 			) {
-				this.log.error('Invalid Gemini response structure', {
+				this.log.error("Invalid Gemini response structure", {
 					result: JSON.stringify(result),
 				});
-				throw new Error('AIからの応答形式が不正です。');
+				throw new Error("AIからの応答形式が不正です。");
 			}
 
 			const response = result.candidates[0].content.parts[0].text;
 
-			if (!response || typeof response !== 'string' || !response.trim()) {
-				this.log.error('Empty or invalid text in Gemini response');
-				throw new Error('AIから有効な応答が得られませんでした。');
+			if (!response || typeof response !== "string" || !response.trim()) {
+				this.log.error("Empty or invalid text in Gemini response");
+				throw new Error("AIから有効な応答が得られませんでした。");
 			}
 
 			// Add to history
 			this.history.push({
-				role: 'user',
+				role: "user",
 				text: `質問: ${input}`,
 			});
 			this.history.push({
-				role: 'model',
+				role: "model",
 				text: response,
 			});
 
 			return response;
 		} catch (error) {
 			// Preserve user-friendly errors
-			if (error instanceof Error && (error.message.includes('API') || error.message.includes('AI'))) {
+			if (
+				error instanceof Error &&
+				(error.message.includes("API") || error.message.includes("AI"))
+			) {
 				throw error;
 			}
 
-			this.log.error('Unexpected error in Gemini client', {
-				error: error instanceof Error ? error.message : 'Unknown error',
+			this.log.error("Unexpected error in Gemini client", {
+				error: error instanceof Error ? error.message : "Unknown error",
 			});
-			throw new Error('AI処理中に予期しないエラーが発生しました。');
+			throw new Error("AI処理中に予期しないエラーが発生しました。");
 		}
 	}
 
@@ -129,7 +152,11 @@ ${historyText ? `会話履歴:\n${historyText}\n\n` : ''}質問: ${input}`;
 	}
 }
 
-export const createGeminiClient = (apiKey: string, initialHistory: { role: string; text: string }[] = [], log?: Logger): GeminiClient => {
+export const createGeminiClient = (
+	apiKey: string,
+	initialHistory: { role: string; text: string }[] = [],
+	log?: Logger,
+): GeminiClient => {
 	return new GeminiClient(apiKey, initialHistory, log);
 };
 
@@ -138,7 +165,7 @@ const generationConfig = {
 	topP: 0.95,
 	topK: 40,
 	maxOutputTokens: 8192,
-	responseMimeType: 'text/plain',
+	responseMimeType: "text/plain",
 };
 
 const getPrompt = (sheet: string, description: string) => {

--- a/src/clients/kv.test.ts
+++ b/src/clients/kv.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
-import { createKV, KV } from './kv';
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { createKV, KV } from "./kv";
 
 const createMockKVNamespace = () =>
 	({
@@ -10,7 +10,7 @@ const createMockKVNamespace = () =>
 		getWithMetadata: vi.fn(),
 	}) as unknown as KVNamespace;
 
-describe('KV class', () => {
+describe("KV class", () => {
 	let mockKV: KVNamespace;
 	let kv: KV;
 
@@ -20,29 +20,33 @@ describe('KV class', () => {
 		kv = new KV(mockKV);
 	});
 
-	describe('saveHistory', () => {
-		it('saves history with expirationTtl', async () => {
-			const history = [{ role: 'user', text: 'hello' }];
+	describe("saveHistory", () => {
+		it("saves history with expirationTtl", async () => {
+			const history = [{ role: "user", text: "hello" }];
 
 			await kv.saveHistory(history);
 
-			expect(mockKV.put).toHaveBeenCalledWith('chat_history', JSON.stringify([{ role: 'user', text: 'hello' }]), { expirationTtl: 300 });
+			expect(mockKV.put).toHaveBeenCalledWith(
+				"chat_history",
+				JSON.stringify([{ role: "user", text: "hello" }]),
+				{ expirationTtl: 300 },
+			);
 		});
 
-		it('strips extra fields from history entries', async () => {
+		it("strips extra fields from history entries", async () => {
 			// biome-ignore lint/suspicious/noExplicitAny: intentionally passing extra fields to test stripping behavior
-			const history = [{ role: 'user', text: 'hello', extra: 'field' }] as any;
+			const history = [{ role: "user", text: "hello", extra: "field" }] as any;
 
 			await kv.saveHistory(history);
 
 			const savedData = JSON.parse((mockKV.put as Mock).mock.calls[0][1]);
-			expect(savedData[0]).toEqual({ role: 'user', text: 'hello' });
-			expect(savedData[0]).not.toHaveProperty('extra');
+			expect(savedData[0]).toEqual({ role: "user", text: "hello" });
+			expect(savedData[0]).not.toHaveProperty("extra");
 		});
 	});
 
-	describe('getHistory', () => {
-		it('returns empty array when no history exists', async () => {
+	describe("getHistory", () => {
+		it("returns empty array when no history exists", async () => {
 			(mockKV.get as Mock).mockResolvedValue(null);
 
 			const result = await kv.getHistory();
@@ -50,43 +54,46 @@ describe('KV class', () => {
 			expect(result).toEqual([]);
 		});
 
-		it('returns all history entries (TTL handled by KV)', async () => {
+		it("returns all history entries (TTL handled by KV)", async () => {
 			(mockKV.get as Mock).mockResolvedValue([
-				{ role: 'user', text: 'first' },
-				{ role: 'model', text: 'response' },
+				{ role: "user", text: "first" },
+				{ role: "model", text: "response" },
 			]);
 
 			const result = await kv.getHistory();
 
 			expect(result).toHaveLength(2);
-			expect(result[0]).toEqual({ role: 'user', text: 'first' });
-			expect(result[1]).toEqual({ role: 'model', text: 'response' });
+			expect(result[0]).toEqual({ role: "user", text: "first" });
+			expect(result[1]).toEqual({ role: "model", text: "response" });
 		});
 
-		it('filters out invalid entries', async () => {
+		it("filters out invalid entries", async () => {
 			(mockKV.get as Mock).mockResolvedValue([
-				{ role: 'user', text: 'valid' },
+				{ role: "user", text: "valid" },
 				null,
-				{ role: 123, text: 'invalid role' },
-				{ role: 'user' },
+				{ role: 123, text: "invalid role" },
+				{ role: "user" },
 			]);
 
 			const result = await kv.getHistory();
 
 			expect(result).toHaveLength(1);
-			expect(result[0].text).toBe('valid');
+			expect(result[0].text).toBe("valid");
 		});
 
-		it('returns empty array when data is not an array', async () => {
-			(mockKV.get as Mock).mockResolvedValue({ role: 'user', text: 'not array' });
+		it("returns empty array when data is not an array", async () => {
+			(mockKV.get as Mock).mockResolvedValue({
+				role: "user",
+				text: "not array",
+			});
 
 			const result = await kv.getHistory();
 
 			expect(result).toEqual([]);
 		});
 
-		it('returns empty array on KV error', async () => {
-			(mockKV.get as Mock).mockRejectedValue(new Error('KV error'));
+		it("returns empty array on KV error", async () => {
+			(mockKV.get as Mock).mockRejectedValue(new Error("KV error"));
 
 			const result = await kv.getHistory();
 
@@ -94,8 +101,8 @@ describe('KV class', () => {
 		});
 	});
 
-	describe('getCache', () => {
-		it('returns null when no cache exists', async () => {
+	describe("getCache", () => {
+		it("returns null when no cache exists", async () => {
 			(mockKV.get as Mock).mockResolvedValue(null);
 
 			const result = await kv.getCache();
@@ -103,22 +110,22 @@ describe('KV class', () => {
 			expect(result).toBeNull();
 		});
 
-		it('returns cached data (TTL handled by KV)', async () => {
+		it("returns cached data (TTL handled by KV)", async () => {
 			const validCache = {
-				sheetInfo: 'sheet data',
-				description: 'description',
+				sheetInfo: "sheet data",
+				description: "description",
 			};
 			(mockKV.get as Mock).mockResolvedValue(validCache);
 
 			const result = await kv.getCache();
 
 			expect(result).toEqual({
-				sheetInfo: 'sheet data',
-				description: 'description',
+				sheetInfo: "sheet data",
+				description: "description",
 			});
 		});
 
-		it('returns null for invalid cache structure', async () => {
+		it("returns null for invalid cache structure", async () => {
 			(mockKV.get as Mock).mockResolvedValue({ sheetInfo: 123 });
 
 			const result = await kv.getCache();
@@ -126,8 +133,8 @@ describe('KV class', () => {
 			expect(result).toBeNull();
 		});
 
-		it('returns null on KV error', async () => {
-			(mockKV.get as Mock).mockRejectedValue(new Error('KV error'));
+		it("returns null on KV error", async () => {
+			(mockKV.get as Mock).mockRejectedValue(new Error("KV error"));
 
 			const result = await kv.getCache();
 
@@ -135,18 +142,22 @@ describe('KV class', () => {
 		});
 	});
 
-	describe('saveCache', () => {
-		it('saves cache with expirationTtl', async () => {
-			await kv.saveCache('sheet info', 'description');
+	describe("saveCache", () => {
+		it("saves cache with expirationTtl", async () => {
+			await kv.saveCache("sheet info", "description");
 
-			expect(mockKV.put).toHaveBeenCalledWith('sheet_info', JSON.stringify({ sheetInfo: 'sheet info', description: 'description' }), {
-				expirationTtl: 300,
-			});
+			expect(mockKV.put).toHaveBeenCalledWith(
+				"sheet_info",
+				JSON.stringify({ sheetInfo: "sheet info", description: "description" }),
+				{
+					expirationTtl: 300,
+				},
+			);
 		});
 	});
 
-	describe('createKV', () => {
-		it('creates a new KV instance', () => {
+	describe("createKV", () => {
+		it("creates a new KV instance", () => {
 			const instance = createKV(mockKV);
 			expect(instance).toBeInstanceOf(KV);
 		});

--- a/src/clients/kv.ts
+++ b/src/clients/kv.ts
@@ -1,8 +1,8 @@
-import { logger as defaultLogger, type Logger } from '../utils/logger';
+import { logger as defaultLogger, type Logger } from "../utils/logger";
 
 // KV用のキー
-const SHEET_INFO = 'sheet_info';
-const HISTORY_KEY = 'chat_history';
+const SHEET_INFO = "sheet_info";
+const HISTORY_KEY = "chat_history";
 
 // キャッシュの持続時間（秒）- KVネイティブTTLで使用
 const CACHE_TTL_SECONDS = 5 * 60; // 5分
@@ -38,30 +38,39 @@ export class KV {
 				expirationTtl: CACHE_TTL_SECONDS,
 			});
 		} catch (error) {
-			this.log.error('Failed to save history to KV', {
-				error: error instanceof Error ? error.message : 'Unknown error',
+			this.log.error("Failed to save history to KV", {
+				error: error instanceof Error ? error.message : "Unknown error",
 			});
-			throw new Error('Failed to save conversation history');
+			throw new Error("Failed to save conversation history");
 		}
 	}
 
 	async getHistory(): Promise<{ role: string; text: string }[]> {
 		try {
 			// KVネイティブTTLにより期限切れデータは自動的にnullになる
-			const parsedHistory = await this.kv.get<ChatHistory[]>(HISTORY_KEY, 'json');
+			const parsedHistory = await this.kv.get<ChatHistory[]>(
+				HISTORY_KEY,
+				"json",
+			);
 			if (!parsedHistory) return [];
 
 			if (!Array.isArray(parsedHistory)) {
-				this.log.warn('History data is not an array, returning empty array');
+				this.log.warn("History data is not an array, returning empty array");
 				return [];
 			}
 
 			return parsedHistory
-				.filter((h): h is ChatHistory => !!h && typeof h === 'object' && typeof h.role === 'string' && typeof h.text === 'string')
+				.filter(
+					(h): h is ChatHistory =>
+						!!h &&
+						typeof h === "object" &&
+						typeof h.role === "string" &&
+						typeof h.text === "string",
+				)
 				.map(({ role, text }) => ({ role, text }));
 		} catch (error) {
-			this.log.error('Failed to get history from KV', {
-				error: error instanceof Error ? error.message : 'Unknown error',
+			this.log.error("Failed to get history from KV", {
+				error: error instanceof Error ? error.message : "Unknown error",
 			});
 			return [];
 		}
@@ -70,18 +79,22 @@ export class KV {
 	async getCache(): Promise<SheetInfo | null> {
 		try {
 			// KVネイティブTTLにより期限切れデータは自動的にnullになる
-			const cachedData = await this.kv.get<SheetInfo>(SHEET_INFO, 'json');
+			const cachedData = await this.kv.get<SheetInfo>(SHEET_INFO, "json");
 			if (!cachedData) return null;
 
-			if (typeof cachedData !== 'object' || typeof cachedData.sheetInfo !== 'string' || typeof cachedData.description !== 'string') {
-				this.log.warn('Invalid cache data structure, ignoring cache');
+			if (
+				typeof cachedData !== "object" ||
+				typeof cachedData.sheetInfo !== "string" ||
+				typeof cachedData.description !== "string"
+			) {
+				this.log.warn("Invalid cache data structure, ignoring cache");
 				return null;
 			}
 
 			return cachedData;
 		} catch (error) {
-			this.log.error('Failed to get cache from KV', {
-				error: error instanceof Error ? error.message : 'Unknown error',
+			this.log.error("Failed to get cache from KV", {
+				error: error instanceof Error ? error.message : "Unknown error",
 			});
 			return null;
 		}
@@ -98,10 +111,10 @@ export class KV {
 				expirationTtl: CACHE_TTL_SECONDS,
 			});
 		} catch (error) {
-			this.log.error('Failed to save cache to KV', {
-				error: error instanceof Error ? error.message : 'Unknown error',
+			this.log.error("Failed to save cache to KV", {
+				error: error instanceof Error ? error.message : "Unknown error",
 			});
-			throw new Error('Failed to save cache data');
+			throw new Error("Failed to save cache data");
 		}
 	}
 }

--- a/src/clients/metrics.test.ts
+++ b/src/clients/metrics.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Logger } from '../utils/logger';
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Logger } from "../utils/logger";
 import {
 	createMetricsClient,
 	type DiscordWebhookMetricData,
@@ -9,7 +9,7 @@ import {
 	MetricsClient,
 	NoOpMetricsClient,
 	type WorkflowMetricData,
-} from './metrics';
+} from "./metrics";
 
 // Mock logger
 const mockLogger: Logger = {
@@ -26,20 +26,23 @@ const createMockDataset = () => ({
 	writeDataPoint: vi.fn(),
 });
 
-describe('MetricsClient', () => {
+describe("MetricsClient", () => {
 	let mockDataset: ReturnType<typeof createMockDataset>;
 	let metrics: MetricsClient;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockDataset = createMockDataset();
-		metrics = new MetricsClient(mockDataset as unknown as AnalyticsEngineDataset, mockLogger);
+		metrics = new MetricsClient(
+			mockDataset as unknown as AnalyticsEngineDataset,
+			mockLogger,
+		);
 	});
 
-	describe('recordGeminiCall', () => {
-		it('writes data point with correct structure for success', () => {
+	describe("recordGeminiCall", () => {
+		it("writes data point with correct structure for success", () => {
 			const data: GeminiMetricData = {
-				requestId: 'req_abc123',
+				requestId: "req_abc123",
 				success: true,
 				durationMs: 1500,
 				retryCount: 0,
@@ -48,15 +51,15 @@ describe('MetricsClient', () => {
 			metrics.recordGeminiCall(data);
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
-				indexes: ['req_abc123'],
-				blobs: ['gemini_api_call', 'req_abc123'],
+				indexes: ["req_abc123"],
+				blobs: ["gemini_api_call", "req_abc123"],
 				doubles: [1500, 1, 0],
 			});
 		});
 
-		it('records failure with success=0', () => {
+		it("records failure with success=0", () => {
 			const data: GeminiMetricData = {
-				requestId: 'req_xyz789',
+				requestId: "req_xyz789",
 				success: false,
 				durationMs: 500,
 				retryCount: 2,
@@ -65,15 +68,15 @@ describe('MetricsClient', () => {
 			metrics.recordGeminiCall(data);
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
-				indexes: ['req_xyz789'],
-				blobs: ['gemini_api_call', 'req_xyz789'],
+				indexes: ["req_xyz789"],
+				blobs: ["gemini_api_call", "req_xyz789"],
 				doubles: [500, 0, 2],
 			});
 		});
 
-		it('defaults retryCount to 0 when not provided', () => {
+		it("defaults retryCount to 0 when not provided", () => {
 			const data: GeminiMetricData = {
-				requestId: 'req_123',
+				requestId: "req_123",
 				success: true,
 				durationMs: 100,
 			};
@@ -81,14 +84,14 @@ describe('MetricsClient', () => {
 			metrics.recordGeminiCall(data);
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
-				indexes: ['req_123'],
-				blobs: ['gemini_api_call', 'req_123'],
+				indexes: ["req_123"],
+				blobs: ["gemini_api_call", "req_123"],
 				doubles: [100, 1, 0],
 			});
 		});
 
-		it('truncates long requestId in index to 96 bytes', () => {
-			const longRequestId = `req_${'a'.repeat(100)}`;
+		it("truncates long requestId in index to 96 bytes", () => {
+			const longRequestId = `req_${"a".repeat(100)}`;
 			const data: GeminiMetricData = {
 				requestId: longRequestId,
 				success: true,
@@ -99,17 +102,17 @@ describe('MetricsClient', () => {
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
 				indexes: [longRequestId.substring(0, 96)],
-				blobs: ['gemini_api_call', longRequestId],
+				blobs: ["gemini_api_call", longRequestId],
 				doubles: [100, 1, 0],
 			});
 		});
 	});
 
-	describe('recordWorkflowComplete', () => {
-		it('writes data point with correct structure', () => {
+	describe("recordWorkflowComplete", () => {
+		it("writes data point with correct structure", () => {
 			const data: WorkflowMetricData = {
-				requestId: 'req_workflow',
-				workflowId: 'wf_abc123',
+				requestId: "req_workflow",
+				workflowId: "wf_abc123",
 				success: true,
 				durationMs: 5000,
 				stepCount: 5,
@@ -119,16 +122,16 @@ describe('MetricsClient', () => {
 			metrics.recordWorkflowComplete(data);
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
-				indexes: ['req_workflow'],
-				blobs: ['workflow_complete', 'req_workflow', 'wf_abc123'],
+				indexes: ["req_workflow"],
+				blobs: ["workflow_complete", "req_workflow", "wf_abc123"],
 				doubles: [5000, 1, 5, 1],
 			});
 		});
 
-		it('records failure with fromCache=false', () => {
+		it("records failure with fromCache=false", () => {
 			const data: WorkflowMetricData = {
-				requestId: 'req_fail',
-				workflowId: 'wf_fail',
+				requestId: "req_fail",
+				workflowId: "wf_fail",
 				success: false,
 				durationMs: 1000,
 				stepCount: 3,
@@ -138,73 +141,73 @@ describe('MetricsClient', () => {
 			metrics.recordWorkflowComplete(data);
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
-				indexes: ['req_fail'],
-				blobs: ['workflow_complete', 'req_fail', 'wf_fail'],
+				indexes: ["req_fail"],
+				blobs: ["workflow_complete", "req_fail", "wf_fail"],
 				doubles: [1000, 0, 3, 0],
 			});
 		});
 	});
 
-	describe('recordKVCacheAccess', () => {
-		it('records cache hit correctly', () => {
+	describe("recordKVCacheAccess", () => {
+		it("records cache hit correctly", () => {
 			const data: KVCacheMetricData = {
-				requestId: 'req_cache',
+				requestId: "req_cache",
 				success: true,
 				durationMs: 5,
 				cacheHit: true,
-				operation: 'get',
+				operation: "get",
 			};
 
 			metrics.recordKVCacheAccess(data);
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
-				indexes: ['req_cache'],
-				blobs: ['kv_cache_access', 'req_cache', 'get'],
+				indexes: ["req_cache"],
+				blobs: ["kv_cache_access", "req_cache", "get"],
 				doubles: [5, 1, 1],
 			});
 		});
 
-		it('records cache miss correctly', () => {
+		it("records cache miss correctly", () => {
 			const data: KVCacheMetricData = {
-				requestId: 'req_miss',
+				requestId: "req_miss",
 				success: true,
 				durationMs: 10,
 				cacheHit: false,
-				operation: 'get',
+				operation: "get",
 			};
 
 			metrics.recordKVCacheAccess(data);
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
-				indexes: ['req_miss'],
-				blobs: ['kv_cache_access', 'req_miss', 'get'],
+				indexes: ["req_miss"],
+				blobs: ["kv_cache_access", "req_miss", "get"],
 				doubles: [10, 1, 0],
 			});
 		});
 
-		it('records put operation', () => {
+		it("records put operation", () => {
 			const data: KVCacheMetricData = {
-				requestId: 'req_put',
+				requestId: "req_put",
 				success: true,
 				durationMs: 15,
 				cacheHit: false,
-				operation: 'put',
+				operation: "put",
 			};
 
 			metrics.recordKVCacheAccess(data);
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
-				indexes: ['req_put'],
-				blobs: ['kv_cache_access', 'req_put', 'put'],
+				indexes: ["req_put"],
+				blobs: ["kv_cache_access", "req_put", "put"],
 				doubles: [15, 1, 0],
 			});
 		});
 	});
 
-	describe('recordDiscordWebhook', () => {
-		it('writes data point with status code', () => {
+	describe("recordDiscordWebhook", () => {
+		it("writes data point with status code", () => {
 			const data: DiscordWebhookMetricData = {
-				requestId: 'req_discord',
+				requestId: "req_discord",
 				success: true,
 				durationMs: 200,
 				retryCount: 0,
@@ -214,15 +217,15 @@ describe('MetricsClient', () => {
 			metrics.recordDiscordWebhook(data);
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
-				indexes: ['req_discord'],
-				blobs: ['discord_webhook', 'req_discord'],
+				indexes: ["req_discord"],
+				blobs: ["discord_webhook", "req_discord"],
 				doubles: [200, 1, 0, 200],
 			});
 		});
 
-		it('records failure with retries', () => {
+		it("records failure with retries", () => {
 			const data: DiscordWebhookMetricData = {
-				requestId: 'req_discord_fail',
+				requestId: "req_discord_fail",
 				success: false,
 				durationMs: 3000,
 				retryCount: 2,
@@ -232,15 +235,15 @@ describe('MetricsClient', () => {
 			metrics.recordDiscordWebhook(data);
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
-				indexes: ['req_discord_fail'],
-				blobs: ['discord_webhook', 'req_discord_fail'],
+				indexes: ["req_discord_fail"],
+				blobs: ["discord_webhook", "req_discord_fail"],
 				doubles: [3000, 0, 2, 500],
 			});
 		});
 
-		it('defaults statusCode to 0 when not provided', () => {
+		it("defaults statusCode to 0 when not provided", () => {
 			const data: DiscordWebhookMetricData = {
-				requestId: 'req_no_status',
+				requestId: "req_no_status",
 				success: false,
 				durationMs: 1000,
 				retryCount: 2,
@@ -249,17 +252,17 @@ describe('MetricsClient', () => {
 			metrics.recordDiscordWebhook(data);
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
-				indexes: ['req_no_status'],
-				blobs: ['discord_webhook', 'req_no_status'],
+				indexes: ["req_no_status"],
+				blobs: ["discord_webhook", "req_no_status"],
 				doubles: [1000, 0, 2, 0],
 			});
 		});
 	});
 
-	describe('recordSheetsApiCall', () => {
-		it('writes data point with correct structure', () => {
+	describe("recordSheetsApiCall", () => {
+		it("writes data point with correct structure", () => {
 			const data: MetricData = {
-				requestId: 'req_sheets',
+				requestId: "req_sheets",
 				success: true,
 				durationMs: 800,
 			};
@@ -267,15 +270,15 @@ describe('MetricsClient', () => {
 			metrics.recordSheetsApiCall(data);
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
-				indexes: ['req_sheets'],
-				blobs: ['sheets_api_call', 'req_sheets'],
+				indexes: ["req_sheets"],
+				blobs: ["sheets_api_call", "req_sheets"],
 				doubles: [800, 1],
 			});
 		});
 
-		it('records failure', () => {
+		it("records failure", () => {
 			const data: MetricData = {
-				requestId: 'req_sheets_fail',
+				requestId: "req_sheets_fail",
 				success: false,
 				durationMs: 5000,
 			};
@@ -283,95 +286,103 @@ describe('MetricsClient', () => {
 			metrics.recordSheetsApiCall(data);
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
-				indexes: ['req_sheets_fail'],
-				blobs: ['sheets_api_call', 'req_sheets_fail'],
+				indexes: ["req_sheets_fail"],
+				blobs: ["sheets_api_call", "req_sheets_fail"],
 				doubles: [5000, 0],
 			});
 		});
 	});
 
-	describe('error handling', () => {
-		it('does not throw when writeDataPoint fails', () => {
+	describe("error handling", () => {
+		it("does not throw when writeDataPoint fails", () => {
 			mockDataset.writeDataPoint.mockImplementation(() => {
-				throw new Error('Dataset error');
+				throw new Error("Dataset error");
 			});
 
 			expect(() => {
 				metrics.recordGeminiCall({
-					requestId: 'req_123',
+					requestId: "req_123",
 					success: true,
 					durationMs: 100,
 				});
 			}).not.toThrow();
 		});
 
-		it('logs warning when writeDataPoint fails', () => {
+		it("logs warning when writeDataPoint fails", () => {
 			mockDataset.writeDataPoint.mockImplementation(() => {
-				throw new Error('Dataset error');
+				throw new Error("Dataset error");
 			});
 
 			metrics.recordGeminiCall({
-				requestId: 'req_123',
+				requestId: "req_123",
 				success: true,
 				durationMs: 100,
 			});
 
-			expect(mockLogger.warn).toHaveBeenCalledWith('Failed to write metric data point', {
-				eventType: 'gemini_api_call',
-				error: 'Dataset error',
-			});
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				"Failed to write metric data point",
+				{
+					eventType: "gemini_api_call",
+					error: "Dataset error",
+				},
+			);
 		});
 	});
 });
 
-describe('NoOpMetricsClient', () => {
-	it('does nothing when called', () => {
+describe("NoOpMetricsClient", () => {
+	it("does nothing when called", () => {
 		const noOp = new NoOpMetricsClient();
 
 		// Should not throw
-		noOp.recordGeminiCall({ requestId: 'x', success: true, durationMs: 0 });
+		noOp.recordGeminiCall({ requestId: "x", success: true, durationMs: 0 });
 		noOp.recordWorkflowComplete({
-			requestId: 'x',
-			workflowId: 'w',
+			requestId: "x",
+			workflowId: "w",
 			success: true,
 			durationMs: 0,
 			stepCount: 0,
 			fromCache: false,
 		});
 		noOp.recordKVCacheAccess({
-			requestId: 'x',
+			requestId: "x",
 			success: true,
 			durationMs: 0,
 			cacheHit: true,
-			operation: 'get',
+			operation: "get",
 		});
 		noOp.recordDiscordWebhook({
-			requestId: 'x',
+			requestId: "x",
 			success: true,
 			durationMs: 0,
 			retryCount: 0,
 		});
-		noOp.recordSheetsApiCall({ requestId: 'x', success: true, durationMs: 0 });
+		noOp.recordSheetsApiCall({ requestId: "x", success: true, durationMs: 0 });
 	});
 });
 
-describe('createMetricsClient', () => {
-	it('creates a MetricsClient instance', () => {
+describe("createMetricsClient", () => {
+	it("creates a MetricsClient instance", () => {
 		const mockDataset = createMockDataset();
-		const client = createMetricsClient(mockDataset as unknown as AnalyticsEngineDataset);
+		const client = createMetricsClient(
+			mockDataset as unknown as AnalyticsEngineDataset,
+		);
 
 		expect(client).toBeInstanceOf(MetricsClient);
 	});
 
-	it('passes logger to MetricsClient', () => {
+	it("passes logger to MetricsClient", () => {
 		const mockDataset = createMockDataset();
 		mockDataset.writeDataPoint.mockImplementation(() => {
-			throw new Error('test');
+			throw new Error("test");
 		});
 
-		const client = createMetricsClient(mockDataset as unknown as AnalyticsEngineDataset, mockLogger);
+		const client = createMetricsClient(
+			mockDataset as unknown as AnalyticsEngineDataset,
+			mockLogger,
+		);
 
-		client.recordGeminiCall({ requestId: 'x', success: true, durationMs: 0 });
+		client.recordGeminiCall({ requestId: "x", success: true, durationMs: 0 });
 
 		expect(mockLogger.warn).toHaveBeenCalled();
 	});

--- a/src/clients/metrics.ts
+++ b/src/clients/metrics.ts
@@ -1,9 +1,14 @@
-import { logger as defaultLogger, type Logger } from '../utils/logger';
+import { logger as defaultLogger, type Logger } from "../utils/logger";
 
 /**
  * Metric event types for categorizing data points
  */
-export type MetricEventType = 'gemini_api_call' | 'workflow_complete' | 'kv_cache_access' | 'discord_webhook' | 'sheets_api_call';
+export type MetricEventType =
+	| "gemini_api_call"
+	| "workflow_complete"
+	| "kv_cache_access"
+	| "discord_webhook"
+	| "sheets_api_call";
 
 /**
  * Base interface for all metric data
@@ -26,7 +31,7 @@ export interface GeminiMetricData extends MetricData {
  */
 export interface KVCacheMetricData extends MetricData {
 	cacheHit: boolean;
-	operation: 'get' | 'put';
+	operation: "get" | "put";
 }
 
 /**
@@ -79,7 +84,7 @@ export class MetricsClient implements IMetricsClient {
 	 * doubles: [durationMs, success, retryCount]
 	 */
 	recordGeminiCall(data: GeminiMetricData): void {
-		this.writeDataPoint('gemini_api_call', {
+		this.writeDataPoint("gemini_api_call", {
 			indexes: [data.requestId.substring(0, 96)],
 			blobs: [data.requestId],
 			doubles: [data.durationMs, data.success ? 1 : 0, data.retryCount ?? 0],
@@ -91,10 +96,15 @@ export class MetricsClient implements IMetricsClient {
 	 * doubles: [durationMs, success, stepCount, fromCache]
 	 */
 	recordWorkflowComplete(data: WorkflowMetricData): void {
-		this.writeDataPoint('workflow_complete', {
+		this.writeDataPoint("workflow_complete", {
 			indexes: [data.requestId.substring(0, 96)],
 			blobs: [data.requestId, data.workflowId],
-			doubles: [data.durationMs, data.success ? 1 : 0, data.stepCount, data.fromCache ? 1 : 0],
+			doubles: [
+				data.durationMs,
+				data.success ? 1 : 0,
+				data.stepCount,
+				data.fromCache ? 1 : 0,
+			],
 		});
 	}
 
@@ -103,7 +113,7 @@ export class MetricsClient implements IMetricsClient {
 	 * doubles: [durationMs, success, cacheHit]
 	 */
 	recordKVCacheAccess(data: KVCacheMetricData): void {
-		this.writeDataPoint('kv_cache_access', {
+		this.writeDataPoint("kv_cache_access", {
 			indexes: [data.requestId.substring(0, 96)],
 			blobs: [data.requestId, data.operation],
 			doubles: [data.durationMs, data.success ? 1 : 0, data.cacheHit ? 1 : 0],
@@ -115,10 +125,15 @@ export class MetricsClient implements IMetricsClient {
 	 * doubles: [durationMs, success, retryCount, statusCode]
 	 */
 	recordDiscordWebhook(data: DiscordWebhookMetricData): void {
-		this.writeDataPoint('discord_webhook', {
+		this.writeDataPoint("discord_webhook", {
 			indexes: [data.requestId.substring(0, 96)],
 			blobs: [data.requestId],
-			doubles: [data.durationMs, data.success ? 1 : 0, data.retryCount, data.statusCode ?? 0],
+			doubles: [
+				data.durationMs,
+				data.success ? 1 : 0,
+				data.retryCount,
+				data.statusCode ?? 0,
+			],
 		});
 	}
 
@@ -127,7 +142,7 @@ export class MetricsClient implements IMetricsClient {
 	 * doubles: [durationMs, success]
 	 */
 	recordSheetsApiCall(data: MetricData): void {
-		this.writeDataPoint('sheets_api_call', {
+		this.writeDataPoint("sheets_api_call", {
 			indexes: [data.requestId.substring(0, 96)],
 			blobs: [data.requestId],
 			doubles: [data.durationMs, data.success ? 1 : 0],
@@ -139,7 +154,10 @@ export class MetricsClient implements IMetricsClient {
 	 * Prepends eventType to blobs for filtering in SQL queries
 	 * Non-blocking - errors are logged but don't affect main flow
 	 */
-	private writeDataPoint(eventType: MetricEventType, dataPoint: { indexes?: string[]; blobs?: string[]; doubles?: number[] }): void {
+	private writeDataPoint(
+		eventType: MetricEventType,
+		dataPoint: { indexes?: string[]; blobs?: string[]; doubles?: number[] },
+	): void {
 		try {
 			const blobsWithType = [eventType, ...(dataPoint.blobs ?? [])];
 
@@ -150,9 +168,9 @@ export class MetricsClient implements IMetricsClient {
 			});
 		} catch (error) {
 			// Log but don't throw - metrics should never break the main flow
-			this.log.warn('Failed to write metric data point', {
+			this.log.warn("Failed to write metric data point", {
 				eventType,
-				error: error instanceof Error ? error.message : 'Unknown error',
+				error: error instanceof Error ? error.message : "Unknown error",
 			});
 		}
 	}
@@ -172,6 +190,9 @@ export class NoOpMetricsClient implements IMetricsClient {
 /**
  * Factory function following existing patterns (createKV, createGeminiClient)
  */
-export function createMetricsClient(dataset: AnalyticsEngineDataset, log?: Logger): MetricsClient {
+export function createMetricsClient(
+	dataset: AnalyticsEngineDataset,
+	log?: Logger,
+): MetricsClient {
 	return new MetricsClient(dataset, log);
 }

--- a/src/clients/spreadSheet.ts
+++ b/src/clients/spreadSheet.ts
@@ -1,17 +1,19 @@
-import GoogleAuth, { type GoogleKey } from 'cloudflare-workers-and-google-oauth';
-import { GoogleSpreadsheet } from 'google-spreadsheet';
-import { logger as defaultLogger, type Logger } from '../utils/logger';
+import GoogleAuth, {
+	type GoogleKey,
+} from "cloudflare-workers-and-google-oauth";
+import { GoogleSpreadsheet } from "google-spreadsheet";
+import { logger as defaultLogger, type Logger } from "../utils/logger";
 
 // スプレッドシートのID
-const DOC_ID = '1sPOk2XqSB3ZB-O0eKl2ZkKYVr_OgvVCZX0xS79FTNfg';
+const DOC_ID = "1sPOk2XqSB3ZB-O0eKl2ZkKYVr_OgvVCZX0xS79FTNfg";
 
 // 定数を上部にまとめる
-const GOOGLE_SCOPES = ['https://www.googleapis.com/auth/spreadsheets'];
-const SHEET_NAME = 'test';
+const GOOGLE_SCOPES = ["https://www.googleapis.com/auth/spreadsheets"];
+const SHEET_NAME = "test";
 
 // スプレッドシートの情報を取得するためのシート
 // A1セルにスプレッドシートの説明が入っている
-const DESCRIPTION_SHEET_NAME = 'description';
+const DESCRIPTION_SHEET_NAME = "description";
 
 // Helper to parse and validate service account JSON
 function parseServiceAccount(serviceAccountJson: string): GoogleKey {
@@ -20,35 +22,42 @@ function parseServiceAccount(serviceAccountJson: string): GoogleKey {
 
 		// Validate required fields
 		if (!parsed.client_email || !parsed.private_key) {
-			throw new Error('Service account JSON missing required fields (client_email, private_key)');
+			throw new Error(
+				"Service account JSON missing required fields (client_email, private_key)",
+			);
 		}
 
 		return parsed as GoogleKey;
 	} catch (error) {
 		if (error instanceof SyntaxError) {
-			throw new Error('Invalid service account JSON format');
+			throw new Error("Invalid service account JSON format");
 		}
 		throw error;
 	}
 }
 
 // Helper to authenticate with Google
-async function authenticateGoogle(serviceAccountJson: string, log: Logger): Promise<string> {
+async function authenticateGoogle(
+	serviceAccountJson: string,
+	log: Logger,
+): Promise<string> {
 	try {
 		const googleAuth = parseServiceAccount(serviceAccountJson);
 		const oauth = new GoogleAuth(googleAuth, GOOGLE_SCOPES);
 		const token = await oauth.getGoogleAuthToken();
 
 		if (!token) {
-			throw new Error('Failed to obtain Google auth token');
+			throw new Error("Failed to obtain Google auth token");
 		}
 
 		return token;
 	} catch (error) {
-		log.error('Google authentication error', {
-			error: error instanceof Error ? error.message : 'Unknown error',
+		log.error("Google authentication error", {
+			error: error instanceof Error ? error.message : "Unknown error",
 		});
-		throw new Error(`Google authentication failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+		throw new Error(
+			`Google authentication failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+		);
 	}
 }
 
@@ -59,7 +68,10 @@ export interface SheetData {
 }
 
 // Helper to fetch sheet info from a loaded document
-async function fetchSheetInfo(doc: GoogleSpreadsheet, log: Logger): Promise<string> {
+async function fetchSheetInfo(
+	doc: GoogleSpreadsheet,
+	log: Logger,
+): Promise<string> {
 	const sheet = doc.sheetsByTitle[SHEET_NAME];
 	if (!sheet) {
 		throw new Error(`Sheet "${SHEET_NAME}" not found in spreadsheet`);
@@ -71,40 +83,48 @@ async function fetchSheetInfo(doc: GoogleSpreadsheet, log: Logger): Promise<stri
 		const csvContent = new TextDecoder().decode(csvBuffer);
 
 		if (!csvContent || csvContent.trim().length === 0) {
-			throw new Error('Sheet returned empty CSV data');
+			throw new Error("Sheet returned empty CSV data");
 		}
 
 		return csvContent;
 	} catch (error) {
-		log.error('Failed to download sheet as CSV', {
-			error: error instanceof Error ? error.message : 'Unknown error',
+		log.error("Failed to download sheet as CSV", {
+			error: error instanceof Error ? error.message : "Unknown error",
 		});
-		throw new Error('シートデータのダウンロードに失敗しました。');
+		throw new Error("シートデータのダウンロードに失敗しました。");
 	}
 }
 
 // Helper to fetch description from a loaded document
-async function fetchSheetDescription(doc: GoogleSpreadsheet, log: Logger): Promise<string> {
+async function fetchSheetDescription(
+	doc: GoogleSpreadsheet,
+	log: Logger,
+): Promise<string> {
 	const sheet = doc.sheetsByTitle[DESCRIPTION_SHEET_NAME];
 	if (!sheet) {
-		log.warn(`Description sheet "${DESCRIPTION_SHEET_NAME}" not found, using empty description`);
-		return '';
+		log.warn(
+			`Description sheet "${DESCRIPTION_SHEET_NAME}" not found, using empty description`,
+		);
+		return "";
 	}
 
 	try {
-		await sheet.loadCells('A1');
-		const cell = sheet.getCellByA1('A1');
-		return cell.value?.toString() || '';
+		await sheet.loadCells("A1");
+		const cell = sheet.getCellByA1("A1");
+		return cell.value?.toString() || "";
 	} catch (error) {
-		log.warn('Failed to load description cell', {
-			error: error instanceof Error ? error.message : 'Unknown error',
+		log.warn("Failed to load description cell", {
+			error: error instanceof Error ? error.message : "Unknown error",
 		});
-		return '';
+		return "";
 	}
 }
 
 // Unified function to fetch both sheet info and description with single authentication
-export async function getSheetData(serviceAccountJson: string, log?: Logger): Promise<SheetData> {
+export async function getSheetData(
+	serviceAccountJson: string,
+	log?: Logger,
+): Promise<SheetData> {
 	const logger = log ?? defaultLogger;
 	try {
 		// Authenticate once
@@ -115,26 +135,35 @@ export async function getSheetData(serviceAccountJson: string, log?: Logger): Pr
 		try {
 			await doc.loadInfo();
 		} catch (error) {
-			logger.error('Failed to load spreadsheet info', {
-				error: error instanceof Error ? error.message : 'Unknown error',
+			logger.error("Failed to load spreadsheet info", {
+				error: error instanceof Error ? error.message : "Unknown error",
 			});
-			throw new Error('スプレッドシートへのアクセスに失敗しました。権限を確認してください。');
+			throw new Error(
+				"スプレッドシートへのアクセスに失敗しました。権限を確認してください。",
+			);
 		}
 
 		// Fetch both sheets in parallel using the same authenticated token
-		const [sheetInfo, description] = await Promise.all([fetchSheetInfo(doc, logger), fetchSheetDescription(doc, logger)]);
+		const [sheetInfo, description] = await Promise.all([
+			fetchSheetInfo(doc, logger),
+			fetchSheetDescription(doc, logger),
+		]);
 
 		return { sheetInfo, description };
 	} catch (error) {
 		// Preserve user-friendly errors, wrap others
-		if (error instanceof Error && (error.message.includes('スプレッドシート') || error.message.includes('シート'))) {
+		if (
+			error instanceof Error &&
+			(error.message.includes("スプレッドシート") ||
+				error.message.includes("シート"))
+		) {
 			throw error;
 		}
 
-		logger.error('Unexpected error in getSheetData', {
-			error: error instanceof Error ? error.message : 'Unknown error',
+		logger.error("Unexpected error in getSheetData", {
+			error: error instanceof Error ? error.message : "Unknown error",
 		});
-		throw new Error('スプレッドシート情報の取得中にエラーが発生しました。');
+		throw new Error("スプレッドシート情報の取得中にエラーが発生しました。");
 	}
 }
 
@@ -142,7 +171,9 @@ export async function getSheetData(serviceAccountJson: string, log?: Logger): Pr
 // serviceAccountJson: Google Service Accountの認証情報(JSON形式の文字列)
 // 戻り値: スプレッドシートの内容をCSV形式で返す
 // Note: This function is kept for backward compatibility. Use getSheetData() for better performance.
-export const getSheetInfo = async (serviceAccountJson: string): Promise<string> => {
+export const getSheetInfo = async (
+	serviceAccountJson: string,
+): Promise<string> => {
 	const { sheetInfo } = await getSheetData(serviceAccountJson);
 	return sheetInfo;
 };
@@ -151,7 +182,9 @@ export const getSheetInfo = async (serviceAccountJson: string): Promise<string> 
 // serviceAccountJson: Google Service Accountの認証情報(JSON形式の文字列)
 // 戻り値: スプレッドシートのdescriptionを返す
 // Note: This function is kept for backward compatibility. Use getSheetData() for better performance.
-export const getSheetDescription = async (serviceAccountJson: string): Promise<string> => {
+export const getSheetDescription = async (
+	serviceAccountJson: string,
+): Promise<string> => {
 	const { description } = await getSheetData(serviceAccountJson);
 	return description;
 };

--- a/src/middleware/verifyDiscordInteraction.test.ts
+++ b/src/middleware/verifyDiscordInteraction.test.ts
@@ -1,15 +1,15 @@
-import { Hono } from 'hono';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { verifyDiscordInteraction } from './verifyDiscordInteraction';
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { verifyDiscordInteraction } from "./verifyDiscordInteraction";
 
-vi.mock('discord-interactions', () => ({
+vi.mock("discord-interactions", () => ({
 	verifyKey: vi.fn(),
 	InteractionResponseType: {
 		PONG: 1,
 	},
 }));
 
-import { verifyKey } from 'discord-interactions';
+import { verifyKey } from "discord-interactions";
 
 const mockVerifyKey = vi.mocked(verifyKey);
 
@@ -20,25 +20,25 @@ const mockExecutionCtx = {
 	passThroughOnException: () => {},
 } as unknown as ExecutionContext;
 
-describe('verifyDiscordInteraction middleware', () => {
+describe("verifyDiscordInteraction middleware", () => {
 	let app: Hono<{ Bindings: Bindings }>;
-	const testEnv: Bindings = { DISCORD_PUBLIC_KEY: 'test-key' };
+	const testEnv: Bindings = { DISCORD_PUBLIC_KEY: "test-key" };
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 
 		app = new Hono<{ Bindings: Bindings }>();
-		app.post('/', verifyDiscordInteraction, (c) => {
+		app.post("/", verifyDiscordInteraction, (c) => {
 			return c.json({ success: true });
 		});
 	});
 
-	it('returns 401 when X-Signature-Ed25519 header is missing', async () => {
-		const req = new Request('http://localhost/', {
-			method: 'POST',
+	it("returns 401 when X-Signature-Ed25519 header is missing", async () => {
+		const req = new Request("http://localhost/", {
+			method: "POST",
 			headers: {
-				'X-Signature-Timestamp': '1234567890',
-				'Content-Type': 'application/json',
+				"X-Signature-Timestamp": "1234567890",
+				"Content-Type": "application/json",
 			},
 			body: JSON.stringify({ type: 2 }),
 		});
@@ -46,15 +46,15 @@ describe('verifyDiscordInteraction middleware', () => {
 		const res = await app.fetch(req, testEnv, mockExecutionCtx);
 
 		expect(res.status).toBe(401);
-		expect(await res.json()).toEqual({ message: 'invalid request signature' });
+		expect(await res.json()).toEqual({ message: "invalid request signature" });
 	});
 
-	it('returns 401 when X-Signature-Timestamp header is missing', async () => {
-		const req = new Request('http://localhost/', {
-			method: 'POST',
+	it("returns 401 when X-Signature-Timestamp header is missing", async () => {
+		const req = new Request("http://localhost/", {
+			method: "POST",
 			headers: {
-				'X-Signature-Ed25519': 'abc123',
-				'Content-Type': 'application/json',
+				"X-Signature-Ed25519": "abc123",
+				"Content-Type": "application/json",
 			},
 			body: JSON.stringify({ type: 2 }),
 		});
@@ -62,18 +62,18 @@ describe('verifyDiscordInteraction middleware', () => {
 		const res = await app.fetch(req, testEnv, mockExecutionCtx);
 
 		expect(res.status).toBe(401);
-		expect(await res.json()).toEqual({ message: 'invalid request signature' });
+		expect(await res.json()).toEqual({ message: "invalid request signature" });
 	});
 
-	it('returns 401 when verifyKey returns false', async () => {
+	it("returns 401 when verifyKey returns false", async () => {
 		mockVerifyKey.mockReturnValue(false);
 
-		const req = new Request('http://localhost/', {
-			method: 'POST',
+		const req = new Request("http://localhost/", {
+			method: "POST",
 			headers: {
-				'X-Signature-Ed25519': 'invalid-sig',
-				'X-Signature-Timestamp': '1234567890',
-				'Content-Type': 'application/json',
+				"X-Signature-Ed25519": "invalid-sig",
+				"X-Signature-Timestamp": "1234567890",
+				"Content-Type": "application/json",
 			},
 			body: JSON.stringify({ type: 2 }),
 		});
@@ -81,19 +81,24 @@ describe('verifyDiscordInteraction middleware', () => {
 		const res = await app.fetch(req, testEnv, mockExecutionCtx);
 
 		expect(res.status).toBe(401);
-		expect(await res.json()).toEqual({ message: 'invalid request signature' });
-		expect(mockVerifyKey).toHaveBeenCalledWith(JSON.stringify({ type: 2 }), 'invalid-sig', '1234567890', 'test-key');
+		expect(await res.json()).toEqual({ message: "invalid request signature" });
+		expect(mockVerifyKey).toHaveBeenCalledWith(
+			JSON.stringify({ type: 2 }),
+			"invalid-sig",
+			"1234567890",
+			"test-key",
+		);
 	});
 
-	it('calls next() for valid PING requests', async () => {
+	it("calls next() for valid PING requests", async () => {
 		mockVerifyKey.mockReturnValue(true);
 
-		const req = new Request('http://localhost/', {
-			method: 'POST',
+		const req = new Request("http://localhost/", {
+			method: "POST",
 			headers: {
-				'X-Signature-Ed25519': 'valid-sig',
-				'X-Signature-Timestamp': '1234567890',
-				'Content-Type': 'application/json',
+				"X-Signature-Ed25519": "valid-sig",
+				"X-Signature-Timestamp": "1234567890",
+				"Content-Type": "application/json",
 			},
 			body: JSON.stringify({ type: 1 }),
 		});
@@ -104,15 +109,15 @@ describe('verifyDiscordInteraction middleware', () => {
 		expect(await res.json()).toEqual({ success: true });
 	});
 
-	it('calls next() for valid non-PING requests', async () => {
+	it("calls next() for valid non-PING requests", async () => {
 		mockVerifyKey.mockReturnValue(true);
 
-		const req = new Request('http://localhost/', {
-			method: 'POST',
+		const req = new Request("http://localhost/", {
+			method: "POST",
 			headers: {
-				'X-Signature-Ed25519': 'valid-sig',
-				'X-Signature-Timestamp': '1234567890',
-				'Content-Type': 'application/json',
+				"X-Signature-Ed25519": "valid-sig",
+				"X-Signature-Timestamp": "1234567890",
+				"Content-Type": "application/json",
 			},
 			body: JSON.stringify({ type: 2 }),
 		});

--- a/src/middleware/verifyDiscordInteraction.ts
+++ b/src/middleware/verifyDiscordInteraction.ts
@@ -1,20 +1,25 @@
-import { verifyKey } from 'discord-interactions';
-import { env } from 'hono/adapter';
-import { createMiddleware } from 'hono/factory';
+import { verifyKey } from "discord-interactions";
+import { env } from "hono/adapter";
+import { createMiddleware } from "hono/factory";
 
 export const verifyDiscordInteraction = createMiddleware(async (c, next) => {
 	const { DISCORD_PUBLIC_KEY } = env<{ DISCORD_PUBLIC_KEY: string }>(c);
-	const signature = c.req.header('X-Signature-Ed25519');
-	const timestamp = c.req.header('X-Signature-Timestamp');
+	const signature = c.req.header("X-Signature-Ed25519");
+	const timestamp = c.req.header("X-Signature-Timestamp");
 	if (!signature || !timestamp) {
-		return c.json({ message: 'invalid request signature' }, 401);
+		return c.json({ message: "invalid request signature" }, 401);
 	}
 
 	const rawBody = await c.req.raw.clone().text();
-	const isValidRequest = verifyKey(rawBody, signature, timestamp, DISCORD_PUBLIC_KEY);
+	const isValidRequest = verifyKey(
+		rawBody,
+		signature,
+		timestamp,
+		DISCORD_PUBLIC_KEY,
+	);
 
 	if (!isValidRequest) {
-		return c.json({ message: 'invalid request signature' }, 401);
+		return c.json({ message: "invalid request signature" }, 401);
 	}
 
 	await next();

--- a/src/responses/errorResponse.test.ts
+++ b/src/responses/errorResponse.test.ts
@@ -1,37 +1,39 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from "vitest";
 
-vi.mock('discord-api-types/v10', () => ({
+vi.mock("discord-api-types/v10", () => ({
 	InteractionResponseType: {
 		ChannelMessageWithSource: 4,
 	},
 }));
 
-import { errorResponse } from './errorResponse';
+import { errorResponse } from "./errorResponse";
 
-describe('errorResponse', () => {
-	it('returns ChannelMessageWithSource type', () => {
-		const result = errorResponse('test error');
+describe("errorResponse", () => {
+	it("returns ChannelMessageWithSource type", () => {
+		const result = errorResponse("test error");
 		// InteractionResponseType.ChannelMessageWithSource = 4
 		expect(result.type).toBe(4);
 	});
 
-	it('includes error header content', () => {
-		const result = errorResponse('test error');
-		expect(result.data.content).toBe('🚨 エラーが発生しました');
+	it("includes error header content", () => {
+		const result = errorResponse("test error");
+		expect(result.data.content).toBe("🚨 エラーが発生しました");
 	});
 
-	it('includes error message in embed description', () => {
-		const result = errorResponse('Database connection failed');
-		expect(result.data.embeds?.[0].description).toBe('Database connection failed');
+	it("includes error message in embed description", () => {
+		const result = errorResponse("Database connection failed");
+		expect(result.data.embeds?.[0].description).toBe(
+			"Database connection failed",
+		);
 	});
 
-	it('uses red color (0xff0000) for error embed', () => {
-		const result = errorResponse('any error');
+	it("uses red color (0xff0000) for error embed", () => {
+		const result = errorResponse("any error");
 		expect(result.data.embeds?.[0].color).toBe(0xff0000);
 	});
 
-	it('handles empty error message', () => {
-		const result = errorResponse('');
-		expect(result.data.embeds?.[0].description).toBe('');
+	it("handles empty error message", () => {
+		const result = errorResponse("");
+		expect(result.data.embeds?.[0].description).toBe("");
 	});
 });

--- a/src/responses/errorResponse.ts
+++ b/src/responses/errorResponse.ts
@@ -1,10 +1,15 @@
-import { type APIInteractionResponseChannelMessageWithSource, InteractionResponseType } from 'discord-api-types/v10';
+import {
+	type APIInteractionResponseChannelMessageWithSource,
+	InteractionResponseType,
+} from "discord-api-types/v10";
 
-export const errorResponse = (errorMessage: string): APIInteractionResponseChannelMessageWithSource => {
+export const errorResponse = (
+	errorMessage: string,
+): APIInteractionResponseChannelMessageWithSource => {
 	return {
 		type: InteractionResponseType.ChannelMessageWithSource,
 		data: {
-			content: '🚨 エラーが発生しました',
+			content: "🚨 エラーが発生しました",
 			embeds: [
 				{
 					color: 0xff0000,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { WorkflowParams } from './workflows/types';
+import type { WorkflowParams } from "./workflows/types";
 
 export type Bindings = {
 	DISCORD_TOKEN: string;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,8 +1,8 @@
 export enum LogLevel {
-	ERROR = 'ERROR',
-	WARN = 'WARN',
-	INFO = 'INFO',
-	DEBUG = 'DEBUG',
+	ERROR = "ERROR",
+	WARN = "WARN",
+	INFO = "INFO",
+	DEBUG = "DEBUG",
 }
 
 export interface LogContext {
@@ -70,7 +70,11 @@ export class Logger {
 	/**
 	 * Performance timing wrapper that logs operation duration
 	 */
-	async trackTiming<T>(operation: string, fn: () => Promise<T>, metadata?: LogContext): Promise<T> {
+	async trackTiming<T>(
+		operation: string,
+		fn: () => Promise<T>,
+		metadata?: LogContext,
+	): Promise<T> {
 		const startTime = Date.now();
 		let success = false;
 

--- a/src/utils/retry.test.ts
+++ b/src/utils/retry.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { withRetry } from './retry';
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withRetry } from "./retry";
 
-describe('withRetry', () => {
+describe("withRetry", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.useFakeTimers();
@@ -11,49 +11,52 @@ describe('withRetry', () => {
 		vi.useRealTimers();
 	});
 
-	describe('successful execution', () => {
-		it('returns result on first attempt', async () => {
-			const mockFn = vi.fn().mockResolvedValue('success');
+	describe("successful execution", () => {
+		it("returns result on first attempt", async () => {
+			const mockFn = vi.fn().mockResolvedValue("success");
 
 			const promise = withRetry(mockFn);
 			await vi.runAllTimersAsync();
 			const result = await promise;
 
-			expect(result).toBe('success');
+			expect(result).toBe("success");
 			expect(mockFn).toHaveBeenCalledTimes(1);
 		});
 
-		it('returns result after retry', async () => {
-			const mockFn = vi.fn().mockRejectedValueOnce(new Error('temporary error')).mockResolvedValueOnce('success');
+		it("returns result after retry", async () => {
+			const mockFn = vi
+				.fn()
+				.mockRejectedValueOnce(new Error("temporary error"))
+				.mockResolvedValueOnce("success");
 
 			const promise = withRetry(mockFn);
 			await vi.runAllTimersAsync();
 			const result = await promise;
 
-			expect(result).toBe('success');
+			expect(result).toBe("success");
 			expect(mockFn).toHaveBeenCalledTimes(2);
 		});
 	});
 
-	describe('retry behavior', () => {
-		it('retries up to maxAttempts times', async () => {
-			const mockFn = vi.fn().mockRejectedValue(new Error('persistent error'));
+	describe("retry behavior", () => {
+		it("retries up to maxAttempts times", async () => {
+			const mockFn = vi.fn().mockRejectedValue(new Error("persistent error"));
 
 			const promise = withRetry(mockFn, { maxAttempts: 3 });
 			await vi.runAllTimersAsync();
 
-			await expect(promise).rejects.toThrow('persistent error');
+			await expect(promise).rejects.toThrow("persistent error");
 			expect(mockFn).toHaveBeenCalledTimes(3);
 		});
 
-		it('uses exponential backoff', async () => {
+		it("uses exponential backoff", async () => {
 			const mockFn = vi
 				.fn()
-				.mockRejectedValueOnce(new Error('error 1'))
-				.mockRejectedValueOnce(new Error('error 2'))
-				.mockResolvedValueOnce('success');
+				.mockRejectedValueOnce(new Error("error 1"))
+				.mockRejectedValueOnce(new Error("error 2"))
+				.mockResolvedValueOnce("success");
 
-			const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+			const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
 			const promise = withRetry(mockFn, {
 				initialDelayMs: 1000,
@@ -72,14 +75,14 @@ describe('withRetry', () => {
 			consoleSpy.mockRestore();
 		});
 
-		it('caps delay at maxDelayMs', async () => {
+		it("caps delay at maxDelayMs", async () => {
 			const mockFn = vi
 				.fn()
-				.mockRejectedValueOnce(new Error('error 1'))
-				.mockRejectedValueOnce(new Error('error 2'))
-				.mockResolvedValueOnce('success');
+				.mockRejectedValueOnce(new Error("error 1"))
+				.mockRejectedValueOnce(new Error("error 2"))
+				.mockResolvedValueOnce("success");
 
-			const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+			const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
 			const promise = withRetry(mockFn, {
 				initialDelayMs: 5000,
@@ -99,120 +102,144 @@ describe('withRetry', () => {
 		});
 	});
 
-	describe('shouldRetry callback', () => {
-		it('stops retrying when shouldRetry returns false', async () => {
-			const mockFn = vi.fn().mockRejectedValue(new Error('non-retryable error'));
+	describe("shouldRetry callback", () => {
+		it("stops retrying when shouldRetry returns false", async () => {
+			const mockFn = vi
+				.fn()
+				.mockRejectedValue(new Error("non-retryable error"));
 
 			const shouldRetry = (error: Error) => {
-				return error.message !== 'non-retryable error';
+				return error.message !== "non-retryable error";
 			};
 
 			const promise = withRetry(mockFn, { maxAttempts: 3 }, shouldRetry);
 			await vi.runAllTimersAsync();
 
-			await expect(promise).rejects.toThrow('non-retryable error');
+			await expect(promise).rejects.toThrow("non-retryable error");
 			expect(mockFn).toHaveBeenCalledTimes(1);
 		});
 
-		it('continues retrying for retryable errors', async () => {
-			const mockFn = vi.fn().mockRejectedValueOnce(new Error('retryable error')).mockResolvedValueOnce('success');
+		it("continues retrying for retryable errors", async () => {
+			const mockFn = vi
+				.fn()
+				.mockRejectedValueOnce(new Error("retryable error"))
+				.mockResolvedValueOnce("success");
 
 			const shouldRetry = (error: Error) => {
-				return error.message.includes('retryable');
+				return error.message.includes("retryable");
 			};
 
 			const promise = withRetry(mockFn, {}, shouldRetry);
 			await vi.runAllTimersAsync();
 			const result = await promise;
 
-			expect(result).toBe('success');
+			expect(result).toBe("success");
 			expect(mockFn).toHaveBeenCalledTimes(2);
 		});
 
-		it('classifies rate limit errors as retryable', async () => {
-			const mockFn = vi.fn().mockRejectedValueOnce(new Error('rate limit exceeded')).mockResolvedValueOnce('success');
+		it("classifies rate limit errors as retryable", async () => {
+			const mockFn = vi
+				.fn()
+				.mockRejectedValueOnce(new Error("rate limit exceeded"))
+				.mockResolvedValueOnce("success");
 
 			const shouldRetry = (error: Error) => {
 				const msg = error.message.toLowerCase();
-				return msg.includes('quota') || msg.includes('rate limit');
+				return msg.includes("quota") || msg.includes("rate limit");
 			};
 
 			const promise = withRetry(mockFn, {}, shouldRetry);
 			await vi.runAllTimersAsync();
 			const result = await promise;
 
-			expect(result).toBe('success');
+			expect(result).toBe("success");
 			expect(mockFn).toHaveBeenCalledTimes(2);
 		});
 
-		it('classifies network errors as retryable', async () => {
-			const mockFn = vi.fn().mockRejectedValueOnce(new Error('network timeout')).mockResolvedValueOnce('success');
+		it("classifies network errors as retryable", async () => {
+			const mockFn = vi
+				.fn()
+				.mockRejectedValueOnce(new Error("network timeout"))
+				.mockResolvedValueOnce("success");
 
 			const shouldRetry = (error: Error) => {
 				const msg = error.message.toLowerCase();
-				return msg.includes('network') || msg.includes('timeout');
+				return msg.includes("network") || msg.includes("timeout");
 			};
 
 			const promise = withRetry(mockFn, {}, shouldRetry);
 			await vi.runAllTimersAsync();
 			const result = await promise;
 
-			expect(result).toBe('success');
+			expect(result).toBe("success");
 			expect(mockFn).toHaveBeenCalledTimes(2);
 		});
 	});
 
-	describe('error handling', () => {
-		it('throws last error after all retries exhausted', async () => {
-			const error1 = new Error('error 1');
-			const error2 = new Error('error 2');
-			const error3 = new Error('final error');
+	describe("error handling", () => {
+		it("throws last error after all retries exhausted", async () => {
+			const error1 = new Error("error 1");
+			const error2 = new Error("error 2");
+			const error3 = new Error("final error");
 
-			const mockFn = vi.fn().mockRejectedValueOnce(error1).mockRejectedValueOnce(error2).mockRejectedValueOnce(error3);
+			const mockFn = vi
+				.fn()
+				.mockRejectedValueOnce(error1)
+				.mockRejectedValueOnce(error2)
+				.mockRejectedValueOnce(error3);
 
 			const promise = withRetry(mockFn, { maxAttempts: 3 });
 			await vi.runAllTimersAsync();
 
-			await expect(promise).rejects.toThrow('final error');
+			await expect(promise).rejects.toThrow("final error");
 		});
 
-		it('converts non-Error values to Error', async () => {
-			const mockFn = vi.fn().mockRejectedValue('string error');
+		it("converts non-Error values to Error", async () => {
+			const mockFn = vi.fn().mockRejectedValue("string error");
 
 			const promise = withRetry(mockFn, { maxAttempts: 1 });
 			await vi.runAllTimersAsync();
 
-			await expect(promise).rejects.toThrow('string error');
+			await expect(promise).rejects.toThrow("string error");
 		});
 	});
 
-	describe('configuration', () => {
-		it('uses default configuration when not provided', async () => {
-			const mockFn = vi.fn().mockRejectedValueOnce(new Error('error')).mockResolvedValueOnce('success');
+	describe("configuration", () => {
+		it("uses default configuration when not provided", async () => {
+			const mockFn = vi
+				.fn()
+				.mockRejectedValueOnce(new Error("error"))
+				.mockResolvedValueOnce("success");
 
 			const promise = withRetry(mockFn);
 			await vi.runAllTimersAsync();
 			const result = await promise;
 
-			expect(result).toBe('success');
+			expect(result).toBe("success");
 		});
 
-		it('merges partial config with defaults', async () => {
-			const mockFn = vi.fn().mockRejectedValueOnce(new Error('error')).mockResolvedValueOnce('success');
+		it("merges partial config with defaults", async () => {
+			const mockFn = vi
+				.fn()
+				.mockRejectedValueOnce(new Error("error"))
+				.mockResolvedValueOnce("success");
 
 			const promise = withRetry(mockFn, { maxAttempts: 2 });
 			await vi.runAllTimersAsync();
 			const result = await promise;
 
-			expect(result).toBe('success');
+			expect(result).toBe("success");
 		});
 	});
 
-	describe('logging', () => {
-		it('logs retry attempts', async () => {
-			const mockFn = vi.fn().mockRejectedValueOnce(new Error('temporary error')).mockResolvedValueOnce('success');
+	describe("logging", () => {
+		it("logs retry attempts", async () => {
+			const mockFn = vi
+				.fn()
+				.mockRejectedValueOnce(new Error("temporary error"))
+				.mockResolvedValueOnce("success");
 
-			const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+			const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
 			const promise = withRetry(mockFn);
 			await vi.runAllTimersAsync();
@@ -220,7 +247,11 @@ describe('withRetry', () => {
 
 			// Logs are now JSON formatted
 			const calls = consoleSpy.mock.calls.map((call) => call[0]);
-			expect(calls.some((c) => c.includes('Retry attempt') && c.includes('temporary error'))).toBe(true);
+			expect(
+				calls.some(
+					(c) => c.includes("Retry attempt") && c.includes("temporary error"),
+				),
+			).toBe(true);
 
 			consoleSpy.mockRestore();
 		});

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,4 +1,4 @@
-import { logger as defaultLogger, type Logger } from './logger';
+import { logger as defaultLogger, type Logger } from "./logger";
 
 export interface RetryConfig {
 	maxAttempts: number;
@@ -17,7 +17,7 @@ const DEFAULT_RETRY_CONFIG: RetryConfig = {
 export class RetryableError extends Error {
 	constructor(message: string) {
 		super(message);
-		this.name = 'RetryableError';
+		this.name = "RetryableError";
 	}
 }
 
@@ -33,7 +33,7 @@ export async function withRetry<T>(
 		...config,
 	};
 
-	let lastError: Error = new Error('Retry failed');
+	let lastError: Error = new Error("Retry failed");
 
 	for (let attempt = 0; attempt < maxAttempts; attempt++) {
 		try {
@@ -47,7 +47,10 @@ export async function withRetry<T>(
 			}
 
 			// Calculate delay with exponential backoff
-			const delay = Math.min(initialDelayMs * backoffMultiplier ** attempt, maxDelayMs);
+			const delay = Math.min(
+				initialDelayMs * backoffMultiplier ** attempt,
+				maxDelayMs,
+			);
 
 			logger.warn(`Retry attempt ${attempt + 1}/${maxAttempts}`, {
 				delayMs: delay,

--- a/src/utils/timeout.ts
+++ b/src/utils/timeout.ts
@@ -4,7 +4,11 @@
  * @param timeoutMs Timeout in milliseconds
  * @param errorMessage Error message to use if timeout occurs
  */
-export async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, errorMessage: string): Promise<T> {
+export async function withTimeout<T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+	errorMessage: string,
+): Promise<T> {
 	let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
 	const timeoutPromise = new Promise<never>((_, reject) => {

--- a/src/workflows/answerQuestionWorkflow.test.ts
+++ b/src/workflows/answerQuestionWorkflow.test.ts
@@ -1,7 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Bindings } from '../types';
-import type { Logger } from '../utils/logger';
-import type { HistoryOutput, SheetDataOutput } from './types';
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Bindings } from "../types";
+import type { Logger } from "../utils/logger";
+import type { HistoryOutput, SheetDataOutput } from "./types";
 
 // Mock logger
 const mockLogger: Logger = {
@@ -26,21 +26,27 @@ const mockGeminiInstance = {
 	getHistory: vi.fn(),
 };
 
-vi.mock('../clients/kv', () => ({
+vi.mock("../clients/kv", () => ({
 	createKV: vi.fn(() => mockKVInstance),
 }));
 
-vi.mock('../clients/gemini', () => ({
+vi.mock("../clients/gemini", () => ({
 	createGeminiClient: vi.fn(() => mockGeminiInstance),
 }));
 
-vi.mock('../clients/spreadSheet', () => ({
+vi.mock("../clients/spreadSheet", () => ({
 	getSheetData: vi.fn(),
 }));
 
-import { createGeminiClient } from '../clients/gemini';
-import { getSheetData } from '../clients/spreadSheet';
-import { callGeminiStep, getHistoryStep, getSheetDataStep, saveHistoryStep, sendDiscordResponseStep } from './answerQuestionWorkflow';
+import { createGeminiClient } from "../clients/gemini";
+import { getSheetData } from "../clients/spreadSheet";
+import {
+	callGeminiStep,
+	getHistoryStep,
+	getSheetDataStep,
+	saveHistoryStep,
+	sendDiscordResponseStep,
+} from "./answerQuestionWorkflow";
 
 // Mock Analytics Engine Dataset
 const mockAnalyticsDataset = {
@@ -48,13 +54,13 @@ const mockAnalyticsDataset = {
 };
 
 const mockEnv: Bindings = {
-	DISCORD_TOKEN: 'test-token',
-	DISCORD_PUBLIC_KEY: 'test-public-key',
-	DISCORD_APPLICATION_ID: 'test-app-id',
-	DISCORD_TEST_GUILD_ID: 'test-guild-id',
-	GEMINI_API_KEY: 'test-gemini-key',
-	GOOGLE_SERVICE_ACCOUNT_EMAIL: 'test@example.com',
-	GOOGLE_PRIVATE_KEY: 'test-key',
+	DISCORD_TOKEN: "test-token",
+	DISCORD_PUBLIC_KEY: "test-public-key",
+	DISCORD_APPLICATION_ID: "test-app-id",
+	DISCORD_TEST_GUILD_ID: "test-guild-id",
+	GEMINI_API_KEY: "test-gemini-key",
+	GOOGLE_SERVICE_ACCOUNT_EMAIL: "test@example.com",
+	GOOGLE_PRIVATE_KEY: "test-key",
 	GOOGLE_SERVICE_ACCOUNT: '{"type":"service_account"}',
 	sushanshan_bot: {} as KVNamespace,
 	// biome-ignore lint/suspicious/noExplicitAny: mock binding for test
@@ -62,63 +68,69 @@ const mockEnv: Bindings = {
 	METRICS: mockAnalyticsDataset as unknown as AnalyticsEngineDataset,
 };
 
-describe('AnswerQuestionWorkflow Steps', () => {
+describe("AnswerQuestionWorkflow Steps", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		// Reset fetch mock
 		globalThis.fetch = vi.fn();
 	});
 
-	describe('getSheetDataStep', () => {
-		it('returns cached data when cache is available', async () => {
+	describe("getSheetDataStep", () => {
+		it("returns cached data when cache is available", async () => {
 			mockKVInstance.getCache.mockResolvedValue({
-				sheetInfo: 'cached sheet',
-				description: 'cached desc',
+				sheetInfo: "cached sheet",
+				description: "cached desc",
 			});
 
 			const result = await getSheetDataStep(mockEnv, mockLogger);
 
 			expect(result).toEqual({
-				sheetInfo: 'cached sheet',
-				description: 'cached desc',
+				sheetInfo: "cached sheet",
+				description: "cached desc",
 				fromCache: true,
 			});
 			expect(getSheetData).not.toHaveBeenCalled();
 		});
 
-		it('fetches from Google Sheets when cache is empty', async () => {
+		it("fetches from Google Sheets when cache is empty", async () => {
 			mockKVInstance.getCache.mockResolvedValue(null);
 			vi.mocked(getSheetData).mockResolvedValue({
-				sheetInfo: 'fresh sheet',
-				description: 'fresh desc',
+				sheetInfo: "fresh sheet",
+				description: "fresh desc",
 			});
 
 			const result = await getSheetDataStep(mockEnv, mockLogger);
 
 			expect(result).toEqual({
-				sheetInfo: 'fresh sheet',
-				description: 'fresh desc',
+				sheetInfo: "fresh sheet",
+				description: "fresh desc",
 				fromCache: false,
 			});
-			expect(getSheetData).toHaveBeenCalledWith(mockEnv.GOOGLE_SERVICE_ACCOUNT, mockLogger);
+			expect(getSheetData).toHaveBeenCalledWith(
+				mockEnv.GOOGLE_SERVICE_ACCOUNT,
+				mockLogger,
+			);
 		});
 
-		it('saves cache after fetching fresh data', async () => {
+		it("saves cache after fetching fresh data", async () => {
 			mockKVInstance.getCache.mockResolvedValue(null);
 			vi.mocked(getSheetData).mockResolvedValue({
-				sheetInfo: 'fresh sheet',
-				description: 'fresh desc',
+				sheetInfo: "fresh sheet",
+				description: "fresh desc",
 			});
 
 			await getSheetDataStep(mockEnv, mockLogger);
 
-			expect(mockKVInstance.saveCache).toHaveBeenCalledWith('fresh sheet', 'fresh desc');
+			expect(mockKVInstance.saveCache).toHaveBeenCalledWith(
+				"fresh sheet",
+				"fresh desc",
+			);
 		});
 
-		it('does not save cache when using cached data', async () => {
+		it("does not save cache when using cached data", async () => {
 			mockKVInstance.getCache.mockResolvedValue({
-				sheetInfo: 'cached sheet',
-				description: 'cached desc',
+				sheetInfo: "cached sheet",
+				description: "cached desc",
 			});
 
 			await getSheetDataStep(mockEnv, mockLogger);
@@ -127,11 +139,11 @@ describe('AnswerQuestionWorkflow Steps', () => {
 		});
 	});
 
-	describe('getHistoryStep', () => {
-		it('returns history from KV', async () => {
+	describe("getHistoryStep", () => {
+		it("returns history from KV", async () => {
 			const existingHistory = [
-				{ role: 'user', text: 'old question' },
-				{ role: 'model', text: 'old answer' },
+				{ role: "user", text: "old question" },
+				{ role: "model", text: "old answer" },
 			];
 			mockKVInstance.getHistory.mockResolvedValue(existingHistory);
 
@@ -140,7 +152,7 @@ describe('AnswerQuestionWorkflow Steps', () => {
 			expect(result).toEqual({ history: existingHistory });
 		});
 
-		it('returns empty array when no history exists', async () => {
+		it("returns empty array when no history exists", async () => {
 			mockKVInstance.getHistory.mockResolvedValue([]);
 
 			const result = await getHistoryStep(mockEnv, mockLogger);
@@ -149,50 +161,74 @@ describe('AnswerQuestionWorkflow Steps', () => {
 		});
 	});
 
-	describe('callGeminiStep', () => {
-		it('calls Gemini with correct parameters', async () => {
+	describe("callGeminiStep", () => {
+		it("calls Gemini with correct parameters", async () => {
 			const sheetData: SheetDataOutput = {
-				sheetInfo: 'sheet data',
-				description: 'sheet description',
+				sheetInfo: "sheet data",
+				description: "sheet description",
 				fromCache: true,
 			};
 			const history: HistoryOutput = { history: [] };
-			mockGeminiInstance.ask.mockResolvedValue('AI response');
+			mockGeminiInstance.ask.mockResolvedValue("AI response");
 			mockGeminiInstance.getHistory.mockReturnValue([
-				{ role: 'user', text: '質問: test message' },
-				{ role: 'model', text: 'AI response' },
+				{ role: "user", text: "質問: test message" },
+				{ role: "model", text: "AI response" },
 			]);
 
-			const result = await callGeminiStep(mockEnv, 'test message', sheetData, history, mockLogger);
+			const result = await callGeminiStep(
+				mockEnv,
+				"test message",
+				sheetData,
+				history,
+				mockLogger,
+			);
 
-			expect(createGeminiClient).toHaveBeenCalledWith(mockEnv.GEMINI_API_KEY, [], mockLogger);
-			expect(mockGeminiInstance.ask).toHaveBeenCalledWith('test message', 'sheet data', 'sheet description');
-			expect(result.response).toBe('AI response');
+			expect(createGeminiClient).toHaveBeenCalledWith(
+				mockEnv.GEMINI_API_KEY,
+				[],
+				mockLogger,
+			);
+			expect(mockGeminiInstance.ask).toHaveBeenCalledWith(
+				"test message",
+				"sheet data",
+				"sheet description",
+			);
+			expect(result.response).toBe("AI response");
 			expect(result.updatedHistory).toHaveLength(2);
 		});
 
-		it('passes existing history to GeminiClient', async () => {
-			const existingHistory = [{ role: 'user', text: 'previous question' }];
+		it("passes existing history to GeminiClient", async () => {
+			const existingHistory = [{ role: "user", text: "previous question" }];
 			const sheetData: SheetDataOutput = {
-				sheetInfo: 'sheet',
-				description: 'desc',
+				sheetInfo: "sheet",
+				description: "desc",
 				fromCache: true,
 			};
 			const history: HistoryOutput = { history: existingHistory };
-			mockGeminiInstance.ask.mockResolvedValue('response');
+			mockGeminiInstance.ask.mockResolvedValue("response");
 			mockGeminiInstance.getHistory.mockReturnValue([]);
 
-			await callGeminiStep(mockEnv, 'new message', sheetData, history, mockLogger);
+			await callGeminiStep(
+				mockEnv,
+				"new message",
+				sheetData,
+				history,
+				mockLogger,
+			);
 
-			expect(createGeminiClient).toHaveBeenCalledWith(mockEnv.GEMINI_API_KEY, existingHistory, mockLogger);
+			expect(createGeminiClient).toHaveBeenCalledWith(
+				mockEnv.GEMINI_API_KEY,
+				existingHistory,
+				mockLogger,
+			);
 		});
 	});
 
-	describe('saveHistoryStep', () => {
-		it('saves history to KV', async () => {
+	describe("saveHistoryStep", () => {
+		it("saves history to KV", async () => {
 			const updatedHistory = [
-				{ role: 'user', text: 'question' },
-				{ role: 'model', text: 'answer' },
+				{ role: "user", text: "question" },
+				{ role: "model", text: "answer" },
 			];
 
 			const result = await saveHistoryStep(mockEnv, updatedHistory, mockLogger);
@@ -201,8 +237,8 @@ describe('AnswerQuestionWorkflow Steps', () => {
 			expect(result).toEqual({ success: true });
 		});
 
-		it('returns success false on error', async () => {
-			mockKVInstance.saveHistory.mockRejectedValue(new Error('KV error'));
+		it("returns success false on error", async () => {
+			mockKVInstance.saveHistory.mockRejectedValue(new Error("KV error"));
 
 			const result = await saveHistoryStep(mockEnv, [], mockLogger);
 
@@ -210,66 +246,105 @@ describe('AnswerQuestionWorkflow Steps', () => {
 		});
 	});
 
-	describe('sendDiscordResponseStep', () => {
-		it('sends successful response to Discord webhook', async () => {
+	describe("sendDiscordResponseStep", () => {
+		it("sends successful response to Discord webhook", async () => {
 			const mockFetch = vi.fn().mockResolvedValue({
 				ok: true,
 				status: 200,
 			});
 			globalThis.fetch = mockFetch;
 
-			const result = await sendDiscordResponseStep(mockEnv, 'test-token-123', 'user question', 'AI answer', mockLogger);
+			const result = await sendDiscordResponseStep(
+				mockEnv,
+				"test-token-123",
+				"user question",
+				"AI answer",
+				mockLogger,
+			);
 
-			expect(mockFetch).toHaveBeenCalledWith(`https://discord.com/api/v10/webhooks/${mockEnv.DISCORD_APPLICATION_ID}/test-token-123`, {
-				method: 'POST',
-				body: JSON.stringify({ content: '> user question\nAI answer' }),
-				headers: { 'Content-Type': 'application/json' },
-			});
+			expect(mockFetch).toHaveBeenCalledWith(
+				`https://discord.com/api/v10/webhooks/${mockEnv.DISCORD_APPLICATION_ID}/test-token-123`,
+				{
+					method: "POST",
+					body: JSON.stringify({ content: "> user question\nAI answer" }),
+					headers: { "Content-Type": "application/json" },
+				},
+			);
 			expect(result).toEqual({ success: true, statusCode: 200, retryCount: 0 });
 		});
 
-		it('sends error response when AI fails', async () => {
+		it("sends error response when AI fails", async () => {
 			const mockFetch = vi.fn().mockResolvedValue({
 				ok: true,
 				status: 200,
 			});
 			globalThis.fetch = mockFetch;
 
-			const result = await sendDiscordResponseStep(mockEnv, 'token', 'question', null, mockLogger, 'Some error occurred');
+			const result = await sendDiscordResponseStep(
+				mockEnv,
+				"token",
+				"question",
+				null,
+				mockLogger,
+				"Some error occurred",
+			);
 
 			expect(mockFetch).toHaveBeenCalledWith(expect.any(String), {
-				method: 'POST',
-				body: JSON.stringify({ content: '> question\n:rotating_light: エラーが発生しました: Some error occurred' }),
-				headers: { 'Content-Type': 'application/json' },
+				method: "POST",
+				body: JSON.stringify({
+					content:
+						"> question\n:rotating_light: エラーが発生しました: Some error occurred",
+				}),
+				headers: { "Content-Type": "application/json" },
 			});
 			expect(result).toEqual({ success: true, statusCode: 200, retryCount: 0 });
 		});
 
-		it('retries on failure', async () => {
+		it("retries on failure", async () => {
 			const mockFetch = vi
 				.fn()
-				.mockResolvedValueOnce({ ok: false, status: 500, text: () => 'Server error' })
+				.mockResolvedValueOnce({
+					ok: false,
+					status: 500,
+					text: () => "Server error",
+				})
 				.mockResolvedValueOnce({ ok: true, status: 200 });
 			globalThis.fetch = mockFetch;
 
-			const result = await sendDiscordResponseStep(mockEnv, 'token', 'question', 'answer', mockLogger);
+			const result = await sendDiscordResponseStep(
+				mockEnv,
+				"token",
+				"question",
+				"answer",
+				mockLogger,
+			);
 
 			expect(mockFetch).toHaveBeenCalledTimes(2);
 			expect(result).toEqual({ success: true, statusCode: 200, retryCount: 1 });
 		});
 
-		it('returns failure after all retries exhausted', async () => {
+		it("returns failure after all retries exhausted", async () => {
 			const mockFetch = vi.fn().mockResolvedValue({
 				ok: false,
 				status: 500,
-				text: () => Promise.resolve('Server error'),
+				text: () => Promise.resolve("Server error"),
 			});
 			globalThis.fetch = mockFetch;
 
-			const result = await sendDiscordResponseStep(mockEnv, 'token', 'question', 'answer', mockLogger);
+			const result = await sendDiscordResponseStep(
+				mockEnv,
+				"token",
+				"question",
+				"answer",
+				mockLogger,
+			);
 
 			expect(mockFetch).toHaveBeenCalledTimes(3); // Initial + 2 retries
-			expect(result).toEqual({ success: false, statusCode: 500, retryCount: 2 });
+			expect(result).toEqual({
+				success: false,
+				statusCode: 500,
+				retryCount: 2,
+			});
 		});
 	});
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,10 @@
-import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config';
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
 
 export default defineWorkersConfig({
 	test: {
 		poolOptions: {
 			workers: {
-				wrangler: { configPath: './wrangler.toml' },
+				wrangler: { configPath: "./wrangler.toml" },
 			},
 		},
 	},


### PR DESCRIPTION
## Summary
- `biome.json` からカスタム設定 `lineWidth: 140` と `quoteStyle: "single"` を削除
- Biome デフォルト（80文字幅、ダブルクォート）でコードベース全体をリフォーマット
- 24ファイル変更、機能的な変更なし（フォーマットのみ）

## Test plan
- [x] `npm run check:ci` パス
- [x] `npm test` 全81テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)