### PR TITLE
fix: await verifyKey() to properly validate Discord signatures

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("discord-interactions", () => ({
-	verifyKey: vi.fn().mockReturnValue(true),
+	verifyKey: vi.fn().mockResolvedValue(true),
 	InteractionType: {
 		PING: 1,
 		APPLICATION_COMMAND: 2,

--- a/src/middleware/verifyDiscordInteraction.test.ts
+++ b/src/middleware/verifyDiscordInteraction.test.ts
@@ -66,7 +66,7 @@ describe("verifyDiscordInteraction middleware", () => {
 	});
 
 	it("returns 401 when verifyKey returns false", async () => {
-		mockVerifyKey.mockReturnValue(false);
+		mockVerifyKey.mockResolvedValue(false);
 
 		const req = new Request("http://localhost/", {
 			method: "POST",
@@ -91,7 +91,7 @@ describe("verifyDiscordInteraction middleware", () => {
 	});
 
 	it("calls next() for valid PING requests", async () => {
-		mockVerifyKey.mockReturnValue(true);
+		mockVerifyKey.mockResolvedValue(true);
 
 		const req = new Request("http://localhost/", {
 			method: "POST",
@@ -110,7 +110,7 @@ describe("verifyDiscordInteraction middleware", () => {
 	});
 
 	it("calls next() for valid non-PING requests", async () => {
-		mockVerifyKey.mockReturnValue(true);
+		mockVerifyKey.mockResolvedValue(true);
 
 		const req = new Request("http://localhost/", {
 			method: "POST",

--- a/src/middleware/verifyDiscordInteraction.ts
+++ b/src/middleware/verifyDiscordInteraction.ts
@@ -11,7 +11,7 @@ export const verifyDiscordInteraction = createMiddleware(async (c, next) => {
 	}
 
 	const rawBody = await c.req.raw.clone().text();
-	const isValidRequest = verifyKey(
+	const isValidRequest = await verifyKey(
 		rawBody,
 		signature,
 		timestamp,


### PR DESCRIPTION
## Summary
- `verifyKey()` in `discord-interactions` v4.x は async 関数で `Promise<boolean>` を返す。`await` がなかったため、返り値は常に truthy な Promise オブジェクトとなり、**不正な署名でも全リクエストが検証を通過していた**
- Discord の自動セキュリティチェックが失敗し、Interactions Endpoint URL が無効化された原因
- テストの `mockReturnValue` → `mockResolvedValue` に修正し、本番と同じ async 挙動を再現するようにした

## Test plan
- [x] `npm test` - 全98テストパス
- [x] `npm run check:ci` - lint/format チェッククリア
- [ ] `npm run deploy` でデプロイ
- [ ] Discord Developer Portal で Interactions Endpoint URL を再設定して検証通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)