### PR TITLE
chore: enable noFloatingPromises and noMisusedPromises lint rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -10,7 +10,11 @@
 	},
 	"linter": {
 		"rules": {
-			"recommended": true
+			"recommended": true,
+			"nursery": {
+				"noFloatingPromises": "error",
+				"noMisusedPromises": "error"
+			}
 		}
 	}
 }

--- a/scripts/register.js
+++ b/scripts/register.js
@@ -52,4 +52,4 @@ const registerCommands = async () => {
 	}
 };
 
-registerCommands();
+void registerCommands();


### PR DESCRIPTION
## Summary
- Biome の nursery ルール `noFloatingPromises` と `noMisusedPromises` を有効化
- `scripts/register.js` のトップレベル呼び出しに `void` を付けてルールに準拠
- #69 で修正した `await verifyKey()` のようなバグを今後 lint で事前検知可能に

## Test plan
- [x] `npm run check:ci` がエラーなく通ること
- [x] `npm test` で全テスト (98件) が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)