### PR TITLE
docs: update Google Service Account env var documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Required in Cloudflare Workers secrets or `.dev.vars` for local development:
 
 - `DISCORD_TOKEN`, `DISCORD_PUBLIC_KEY`, `DISCORD_APPLICATION_ID` - Discord credentials
 - `GEMINI_API_KEY` - Google Gemini API key
-- `GOOGLE_CLIENT_EMAIL`, `GOOGLE_PRIVATE_KEY` - Google Service Account for Sheets
+- `GOOGLE_SERVICE_ACCOUNT` - Google Service Account credentials (JSON string)
 
 KV namespace `sushanshan_bot` must be bound in wrangler.toml.
 


### PR DESCRIPTION
## Summary
- Update CLAUDE.md to reflect the current environment variable structure
- Replace `GOOGLE_CLIENT_EMAIL` and `GOOGLE_PRIVATE_KEY` with single `GOOGLE_SERVICE_ACCOUNT` (JSON string)

## Test plan
- [ ] Documentation accurately reflects current env var usage
- [ ] No code changes involved

🤖 Generated with [Claude Code](https://claude.com/claude-code)