### PR TITLE
feat: Renovate PR CI失敗時の自動修正ワークフロー

### DIFF
--- a/.github/workflows/renovate-autofix.yml
+++ b/.github/workflows/renovate-autofix.yml
@@ -1,0 +1,124 @@
+name: Renovate Auto-fix
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  autofix:
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - name: Get PR info and check conditions
+        id: pr-info
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            const run = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+            });
+
+            const pullRequests = run.data.pull_requests;
+            if (!pullRequests || pullRequests.length === 0) {
+              console.log('No PRs associated with this workflow run');
+              core.setOutput('should_fix', 'false');
+              return;
+            }
+
+            const prNumber = pullRequests[0].number;
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            // Renovate PR かどうか確認
+            const isRenovate = pr.data.user.login === 'renovate[bot]'
+              && pr.data.head.ref.startsWith('renovate/');
+            if (!isRenovate) {
+              console.log(`PR #${prNumber} is not a Renovate PR`);
+              core.setOutput('should_fix', 'false');
+              return;
+            }
+
+            // ラベルによる重複実行防止
+            const labels = pr.data.labels.map(l => l.name);
+            if (labels.includes('auto-fix-attempted')) {
+              console.log(`PR #${prNumber}: auto-fix already attempted, skipping`);
+              core.setOutput('should_fix', 'false');
+              return;
+            }
+
+            core.setOutput('should_fix', 'true');
+            core.setOutput('pr_number', prNumber.toString());
+
+      - name: Add auto-fix-attempted label
+        if: steps.pr-info.outputs.should_fix == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            const prNumber = ${{ steps.pr-info.outputs.pr_number }};
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'auto-fix-attempted',
+              });
+            } catch (e) {
+              if (e.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: 'auto-fix-attempted',
+                  color: 'fbca04',
+                  description: 'Claude auto-fix was attempted for CI failure',
+                });
+              }
+            }
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: ['auto-fix-attempted'],
+            });
+
+      - name: Post @claude comment to trigger fix
+        if: steps.pr-info.outputs.should_fix == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            const prNumber = ${{ steps.pr-info.outputs.pr_number }};
+            const runId = ${{ github.event.workflow_run.id }};
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}`;
+
+            const body = [
+              '@claude This Renovate dependency update PR has CI failures. Please fix them.',
+              '',
+              `**Failed CI run:** ${runUrl}`,
+              '',
+              'Please:',
+              '1. Check the CI failure logs from the linked workflow run above',
+              '2. Identify what broke (type errors, lint issues, or test failures from the dependency update)',
+              '3. Fix the code to work with the updated dependencies',
+              '4. Run `npm run check` to fix any formatting/lint issues',
+              '5. Run `npm test` to verify tests pass',
+              '6. If `npm run cf-typegen` generates changed types, include those changes',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: body,
+            });


### PR DESCRIPTION
## Summary

- Renovate の依存関係更新PRでCIが失敗した際、Claude Code による自動修正を起動する GitHub Action を追加
- `workflow_run` で CI 失敗を検知 → `@claude` コメントを投稿 → 既存の `claude.yml` が修正を実行
- `auto-fix-attempted` ラベルによる重複実行防止（最大1回のみ）

## 動作フロー

1. Renovate PRのCI失敗を `workflow_run` イベントで検知
2. Renovate PR かつ未試行であることを確認
3. `auto-fix-attempted` ラベルを追加
4. `PAT_TOKEN` で `@claude` コメントを投稿（`henzai` ユーザーとして）
5. 既存の `claude.yml` が起動し、Claude Code がCIログ確認→修正→コミット・プッシュ

## 無限ループ防止

- **ラベルゲーティング**: `auto-fix-attempted` ラベルで最大1回に制限
- **`workflow_run` の構造的制限**: GitHub は `workflow_run` チェーンを3段に制限

## Test plan

- [ ] ワークフローを main にマージ
- [ ] Renovate PRでCI失敗が発生した際に `auto-fix-attempted` ラベルが追加されることを確認
- [ ] `@claude` コメントが投稿されることを確認
- [ ] `claude.yml` がトリガーされて修正コミットがプッシュされることを確認
- [ ] 2回目のCI失敗時にスキップされることを確認（無限ループ防止）

🤖 Generated with [Claude Code](https://claude.com/claude-code)