### PR TITLE
feat: use Opus 4.6 model for Claude Code Actions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,6 +35,5 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          claude_args: "--model claude-opus-4-6"
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,12 +38,5 @@ jobs:
           github_token: ${{ secrets.PAT_TOKEN }}
           additional_permissions: |
             actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: "--model claude-opus-4-6"
 


### PR DESCRIPTION
## Summary
- Claude Code Action (`claude.yml`) と Claude Code Review Action (`claude-code-review.yml`) で使用するモデルを Opus 4.6 (`claude-opus-4-6`) に明示指定
- `claude_args: "--model claude-opus-4-6"` を両ワークフローに追加
- `create-pr` スキルは `model: sonnet` のまま維持（コスト抑制のため）

## Test plan
- [ ] PRで `@claude` メンションし、Actions が Opus 4.6 で動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)