### PR TITLE
refactor: introduce HistoryEntry type for type-safe role constraints

### DIFF
--- a/src/clients/gemini.ts
+++ b/src/clients/gemini.ts
@@ -1,10 +1,11 @@
 import { type GenerateContentResponse, GoogleGenAI } from "@google/genai";
+import type { HistoryEntry } from "../types";
 import { logger as defaultLogger, type Logger } from "../utils/logger";
 import { withRetry } from "../utils/retry";
 
 export class GeminiClient {
 	private client: GoogleGenAI;
-	private history: { role: string; text: string }[];
+	private history: HistoryEntry[];
 	private log: Logger;
 
 	private readonly RETRY_CONFIG = {
@@ -15,7 +16,7 @@ export class GeminiClient {
 
 	constructor(
 		apiKey: string,
-		initialHistory: { role: string; text: string }[] = [],
+		initialHistory: HistoryEntry[] = [],
 		log?: Logger,
 	) {
 		this.client = new GoogleGenAI({ apiKey });
@@ -234,14 +235,14 @@ ${historyText ? `会話履歴:\n${historyText}\n\n` : ""}質問: ${input}`;
 		}
 	}
 
-	getHistory(): { role: string; text: string }[] {
+	getHistory(): HistoryEntry[] {
 		return this.history;
 	}
 }
 
 export const createGeminiClient = (
 	apiKey: string,
-	initialHistory: { role: string; text: string }[] = [],
+	initialHistory: HistoryEntry[] = [],
 	log?: Logger,
 ): GeminiClient => {
 	return new GeminiClient(apiKey, initialHistory, log);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 import type { WorkflowParams } from "./workflows/types";
 
+export type HistoryEntry = { role: "user" | "model"; text: string };
+
 export type Bindings = {
 	DISCORD_TOKEN: string;
 	DISCORD_PUBLIC_KEY: string;

--- a/src/workflows/answerQuestionWorkflow.ts
+++ b/src/workflows/answerQuestionWorkflow.ts
@@ -13,7 +13,7 @@ import {
 	NoOpMetricsClient,
 } from "../clients/metrics";
 import { getSheetData } from "../clients/spreadSheet";
-import type { Bindings } from "../types";
+import type { Bindings, HistoryEntry } from "../types";
 import { type Logger, logger } from "../utils/logger";
 import { withRetry } from "../utils/retry";
 import type {
@@ -86,7 +86,7 @@ export async function getHistoryStep(
 // Step 4: Save conversation history to KV
 export async function saveHistoryStep(
 	env: Bindings,
-	history: { role: string; text: string }[],
+	history: HistoryEntry[],
 	log: Logger,
 ): Promise<SaveHistoryOutput> {
 	try {

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -1,3 +1,5 @@
+import type { HistoryEntry } from "../types";
+
 // Workflow event payload
 export interface WorkflowParams {
 	// Discord interaction token for webhook response
@@ -16,12 +18,12 @@ export interface SheetDataOutput {
 }
 
 export interface HistoryOutput {
-	history: { role: string; text: string }[];
+	history: HistoryEntry[];
 }
 
 export interface StreamingGeminiOutput {
 	response: string;
-	updatedHistory: { role: string; text: string }[];
+	updatedHistory: HistoryEntry[];
 	editCount: number;
 }
 


### PR DESCRIPTION
## Summary

This PR implements the refactoring requested in issue #86 to introduce a common `HistoryEntry` type and replace inline type definitions across the codebase.

## Changes

- Added `export type HistoryEntry = { role: "user" | "model"; text: string };` to `src/types.ts`
- Replaced `{ role: string; text: string }[]` with `HistoryEntry[]` in:
  - `src/clients/gemini.ts`
  - `src/workflows/types.ts`
  - `src/workflows/answerQuestionWorkflow.ts`

## Benefits

- Improves type safety by restricting `role` to union type ("user" | "model")
- Prevents arbitrary string values from being passed as role
- Centralizes the history entry type definition for easier maintenance

## Testing

- All 121 tests pass ✓
- Biome linter/formatter check passed ✓

Closes #86

----
🤖 Generated with [Claude Code](https://claude.ai/code)