### PR TITLE
refactor: extract getErrorMessage utility function

### DIFF
--- a/src/clients/discord.ts
+++ b/src/clients/discord.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from "../utils/errors";
 import { logger as defaultLogger, type Logger } from "../utils/logger";
 
 const DISCORD_API_BASE = "https://discord.com/api/v10";
@@ -40,7 +41,7 @@ export class DiscordWebhookClient {
 			return false;
 		} catch (error) {
 			this.log.warn("Discord PATCH error", {
-				error: error instanceof Error ? error.message : "Unknown error",
+				error: getErrorMessage(error),
 			});
 			return false;
 		}

--- a/src/clients/gemini.ts
+++ b/src/clients/gemini.ts
@@ -1,5 +1,6 @@
 import { type GenerateContentResponse, GoogleGenAI } from "@google/genai";
 import type { HistoryEntry } from "../types";
+import { getErrorMessage } from "../utils/errors";
 import { logger as defaultLogger, type Logger } from "../utils/logger";
 import { withRetry } from "../utils/retry";
 
@@ -53,7 +54,7 @@ ${historyText ? `会話履歴:\n${historyText}\n\n` : ""}質問: ${input}`;
 
 	private handleGeminiError(error: unknown): never {
 		this.log.error("Gemini API request failed", {
-			error: error instanceof Error ? error.message : "Unknown error",
+			error: getErrorMessage(error),
 		});
 
 		if (error instanceof Error) {
@@ -153,7 +154,7 @@ ${historyText ? `会話履歴:\n${historyText}\n\n` : ""}質問: ${input}`;
 			}
 
 			this.log.error("Unexpected error in Gemini client", {
-				error: error instanceof Error ? error.message : "Unknown error",
+				error: getErrorMessage(error),
 			});
 			throw new Error("AI処理中に予期しないエラーが発生しました。");
 		}
@@ -229,7 +230,7 @@ ${historyText ? `会話履歴:\n${historyText}\n\n` : ""}質問: ${input}`;
 			}
 
 			this.log.error("Unexpected error in Gemini streaming client", {
-				error: error instanceof Error ? error.message : "Unknown error",
+				error: getErrorMessage(error),
 			});
 			throw new Error("AI処理中に予期しないエラーが発生しました。");
 		}

--- a/src/clients/kv.ts
+++ b/src/clients/kv.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from "../utils/errors";
 import { logger as defaultLogger, type Logger } from "../utils/logger";
 
 // KV用のキー
@@ -39,7 +40,7 @@ export class KV {
 			});
 		} catch (error) {
 			this.log.error("Failed to save history to KV", {
-				error: error instanceof Error ? error.message : "Unknown error",
+				error: getErrorMessage(error),
 			});
 			throw new Error("Failed to save conversation history");
 		}
@@ -70,7 +71,7 @@ export class KV {
 				.map(({ role, text }) => ({ role, text }));
 		} catch (error) {
 			this.log.error("Failed to get history from KV", {
-				error: error instanceof Error ? error.message : "Unknown error",
+				error: getErrorMessage(error),
 			});
 			return [];
 		}
@@ -94,7 +95,7 @@ export class KV {
 			return cachedData;
 		} catch (error) {
 			this.log.error("Failed to get cache from KV", {
-				error: error instanceof Error ? error.message : "Unknown error",
+				error: getErrorMessage(error),
 			});
 			return null;
 		}
@@ -112,7 +113,7 @@ export class KV {
 			});
 		} catch (error) {
 			this.log.error("Failed to save cache to KV", {
-				error: error instanceof Error ? error.message : "Unknown error",
+				error: getErrorMessage(error),
 			});
 			throw new Error("Failed to save cache data");
 		}

--- a/src/clients/metrics.ts
+++ b/src/clients/metrics.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from "../utils/errors";
 import { logger as defaultLogger, type Logger } from "../utils/logger";
 
 /**
@@ -170,7 +171,7 @@ export class MetricsClient implements IMetricsClient {
 			// Log but don't throw - metrics should never break the main flow
 			this.log.warn("Failed to write metric data point", {
 				eventType,
-				error: error instanceof Error ? error.message : "Unknown error",
+				error: getErrorMessage(error),
 			});
 		}
 	}

--- a/src/clients/spreadSheet.ts
+++ b/src/clients/spreadSheet.ts
@@ -2,6 +2,7 @@ import GoogleAuth, {
 	type GoogleKey,
 } from "cloudflare-workers-and-google-oauth";
 import { GoogleSpreadsheet } from "google-spreadsheet";
+import { getErrorMessage } from "../utils/errors";
 import { logger as defaultLogger, type Logger } from "../utils/logger";
 
 // スプレッドシートのID
@@ -53,11 +54,9 @@ async function authenticateGoogle(
 		return token;
 	} catch (error) {
 		log.error("Google authentication error", {
-			error: error instanceof Error ? error.message : "Unknown error",
+			error: getErrorMessage(error),
 		});
-		throw new Error(
-			`Google authentication failed: ${error instanceof Error ? error.message : "Unknown error"}`,
-		);
+		throw new Error(`Google authentication failed: ${getErrorMessage(error)}`);
 	}
 }
 
@@ -89,7 +88,7 @@ async function fetchSheetInfo(
 		return csvContent;
 	} catch (error) {
 		log.error("Failed to download sheet as CSV", {
-			error: error instanceof Error ? error.message : "Unknown error",
+			error: getErrorMessage(error),
 		});
 		throw new Error("シートデータのダウンロードに失敗しました。");
 	}
@@ -114,7 +113,7 @@ async function fetchSheetDescription(
 		return cell.value?.toString() || "";
 	} catch (error) {
 		log.warn("Failed to load description cell", {
-			error: error instanceof Error ? error.message : "Unknown error",
+			error: getErrorMessage(error),
 		});
 		return "";
 	}
@@ -136,7 +135,7 @@ export async function getSheetData(
 			await doc.loadInfo();
 		} catch (error) {
 			logger.error("Failed to load spreadsheet info", {
-				error: error instanceof Error ? error.message : "Unknown error",
+				error: getErrorMessage(error),
 			});
 			throw new Error(
 				"スプレッドシートへのアクセスに失敗しました。権限を確認してください。",
@@ -161,7 +160,7 @@ export async function getSheetData(
 		}
 
 		logger.error("Unexpected error in getSheetData", {
-			error: error instanceof Error ? error.message : "Unknown error",
+			error: getErrorMessage(error),
 		});
 		throw new Error("スプレッドシート情報の取得中にエラーが発生しました。");
 	}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,3 @@
+export function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : "Unknown error";
+}

--- a/src/workflows/answerQuestionWorkflow.ts
+++ b/src/workflows/answerQuestionWorkflow.ts
@@ -14,6 +14,7 @@ import {
 } from "../clients/metrics";
 import { getSheetData } from "../clients/spreadSheet";
 import type { Bindings, HistoryEntry } from "../types";
+import { getErrorMessage } from "../utils/errors";
 import { type Logger, logger } from "../utils/logger";
 import { withRetry } from "../utils/retry";
 import type {
@@ -61,7 +62,7 @@ export async function getSheetDataStep(
 		log.info("Sheet data cached");
 	} catch (error) {
 		log.warn("Failed to save cache (non-fatal)", {
-			error: error instanceof Error ? error.message : "Unknown error",
+			error: getErrorMessage(error),
 		});
 	}
 
@@ -96,7 +97,7 @@ export async function saveHistoryStep(
 		return { success: true };
 	} catch (error) {
 		log.warn("Failed to save history (non-fatal)", {
-			error: error instanceof Error ? error.message : "Unknown error",
+			error: getErrorMessage(error),
 		});
 		return { success: false };
 	}
@@ -133,7 +134,7 @@ export async function summarizeThinking(
 		return THINKING_FALLBACK;
 	} catch (error) {
 		log.warn("Thinking summarization failed (non-fatal)", {
-			error: error instanceof Error ? error.message : "Unknown error",
+			error: getErrorMessage(error),
 		});
 		return THINKING_FALLBACK;
 	}
@@ -285,7 +286,7 @@ export async function sendDiscordResponseStep(
 		};
 	} catch (error) {
 		// Extract status code from error message if available
-		const errorMsg = error instanceof Error ? error.message : "";
+		const errorMsg = getErrorMessage(error);
 		const match = errorMsg.match(/status (\d+)/);
 		if (match) {
 			statusCode = Number.parseInt(match[1], 10);
@@ -417,8 +418,7 @@ export class AnswerQuestionWorkflow extends WorkflowEntrypoint<
 			});
 		} catch (error) {
 			// Send error response to Discord
-			const errorMessage =
-				error instanceof Error ? error.message : "Unknown error occurred";
+			const errorMessage = getErrorMessage(error);
 			const failureDurationMs = Date.now() - workflowStartTime;
 			log.error("Workflow error", {
 				error: errorMessage,


### PR DESCRIPTION
## Summary

This PR implements the refactoring described in issue #85 by extracting a reusable `getErrorMessage` utility function to eliminate code duplication.

### Changes

- Created `src/utils/errors.ts` with `getErrorMessage` utility function
- Replaced 21 occurrences of `error instanceof Error ? error.message : "Unknown error"` pattern across 6 files:
  - `src/workflows/answerQuestionWorkflow.ts` (5 occurrences)
  - `src/clients/spreadSheet.ts` (6 occurrences)
  - `src/clients/gemini.ts` (4 occurrences)
  - `src/clients/kv.ts` (4 occurrences)
  - `src/clients/metrics.ts` (1 occurrence)
  - `src/clients/discord.ts` (1 occurrence)

### Testing

- All 121 tests pass
- Code formatted with Biome

Fixes #85

🤖 Generated with [Claude Code](https://claude.ai/code)