### PR TITLE
refactor: remove unused callGeminiStep and GeminiOutput

### DIFF
--- a/src/workflows/answerQuestionWorkflow.test.ts
+++ b/src/workflows/answerQuestionWorkflow.test.ts
@@ -60,7 +60,6 @@ vi.mock("@google/genai", () => ({
 import { createGeminiClient } from "../clients/gemini";
 import { getSheetData } from "../clients/spreadSheet";
 import {
-	callGeminiStep,
 	getHistoryStep,
 	getSheetDataStep,
 	saveHistoryStep,
@@ -176,69 +175,6 @@ describe("AnswerQuestionWorkflow Steps", () => {
 			const result = await getHistoryStep(mockEnv, mockLogger);
 
 			expect(result).toEqual({ history: [] });
-		});
-	});
-
-	describe("callGeminiStep", () => {
-		it("calls Gemini with correct parameters", async () => {
-			const sheetData: SheetDataOutput = {
-				sheetInfo: "sheet data",
-				description: "sheet description",
-				fromCache: true,
-			};
-			const history: HistoryOutput = { history: [] };
-			mockGeminiInstance.ask.mockResolvedValue("AI response");
-			mockGeminiInstance.getHistory.mockReturnValue([
-				{ role: "user", text: "質問: test message" },
-				{ role: "model", text: "AI response" },
-			]);
-
-			const result = await callGeminiStep(
-				mockEnv,
-				"test message",
-				sheetData,
-				history,
-				mockLogger,
-			);
-
-			expect(createGeminiClient).toHaveBeenCalledWith(
-				mockEnv.GEMINI_API_KEY,
-				[],
-				mockLogger,
-			);
-			expect(mockGeminiInstance.ask).toHaveBeenCalledWith(
-				"test message",
-				"sheet data",
-				"sheet description",
-			);
-			expect(result.response).toBe("AI response");
-			expect(result.updatedHistory).toHaveLength(2);
-		});
-
-		it("passes existing history to GeminiClient", async () => {
-			const existingHistory = [{ role: "user", text: "previous question" }];
-			const sheetData: SheetDataOutput = {
-				sheetInfo: "sheet",
-				description: "desc",
-				fromCache: true,
-			};
-			const history: HistoryOutput = { history: existingHistory };
-			mockGeminiInstance.ask.mockResolvedValue("response");
-			mockGeminiInstance.getHistory.mockReturnValue([]);
-
-			await callGeminiStep(
-				mockEnv,
-				"new message",
-				sheetData,
-				history,
-				mockLogger,
-			);
-
-			expect(createGeminiClient).toHaveBeenCalledWith(
-				mockEnv.GEMINI_API_KEY,
-				existingHistory,
-				mockLogger,
-			);
 		});
 	});
 

--- a/src/workflows/answerQuestionWorkflow.ts
+++ b/src/workflows/answerQuestionWorkflow.ts
@@ -17,7 +17,6 @@ import type { Bindings } from "../types";
 import { type Logger, logger } from "../utils/logger";
 import type {
 	DiscordResponseOutput,
-	GeminiOutput,
 	HistoryOutput,
 	SaveHistoryOutput,
 	SheetDataOutput,
@@ -81,34 +80,6 @@ export async function getHistoryStep(
 	const history = await kv.getHistory();
 	log.info("History loaded", { historyLength: history.length });
 	return { history };
-}
-
-// Step 3: Call Gemini API
-export async function callGeminiStep(
-	env: Bindings,
-	message: string,
-	sheetData: SheetDataOutput,
-	historyOutput: HistoryOutput,
-	log: Logger,
-): Promise<GeminiOutput> {
-	log.info("Calling Gemini API", { messageLength: message.length });
-	const gemini = createGeminiClient(
-		env.GEMINI_API_KEY,
-		historyOutput.history,
-		log,
-	);
-	const response = await gemini.ask(
-		message,
-		sheetData.sheetInfo,
-		sheetData.description,
-	);
-	const updatedHistory = gemini.getHistory();
-	log.info("Gemini response received", { responseLength: response.length });
-
-	return {
-		response,
-		updatedHistory,
-	};
 }
 
 // Step 4: Save conversation history to KV

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -19,11 +19,6 @@ export interface HistoryOutput {
 	history: { role: string; text: string }[];
 }
 
-export interface GeminiOutput {
-	response: string;
-	updatedHistory: { role: string; text: string }[];
-}
-
 export interface StreamingGeminiOutput {
 	response: string;
 	updatedHistory: { role: string; text: string }[];


### PR DESCRIPTION
## Summary

Removes unused dead code as described in issue #84:

- Remove `callGeminiStep` function from `src/workflows/answerQuestionWorkflow.ts` (replaced by `streamGeminiWithDiscordEditsStep`)
- Remove `GeminiOutput` interface from `src/workflows/types.ts` (only used by `callGeminiStep`)
- Remove tests for `callGeminiStep` from `src/workflows/answerQuestionWorkflow.test.ts`

## Test Results

✅ All 119 tests pass
✅ Biome linter/formatter checks pass

Fixes #84

---

Generated with [Claude Code](https://claude.ai/code)