### PR TITLE
refactor: use DiscordWebhookClient and withRetry in sendDiscordResponseStep

### DIFF
--- a/src/clients/discord.ts
+++ b/src/clients/discord.ts
@@ -45,6 +45,26 @@ export class DiscordWebhookClient {
 			return false;
 		}
 	}
+
+	/**
+	 * Post a new message to the webhook (POST).
+	 * Used for sending responses (e.g., error messages).
+	 * Throws on failure.
+	 */
+	async postMessage(content: string): Promise<boolean> {
+		const res = await fetch(this.endpoint, {
+			method: "POST",
+			body: JSON.stringify({ content }),
+			headers: { "Content-Type": "application/json" },
+		});
+
+		if (!res.ok) {
+			throw new Error(`Discord POST failed with status ${res.status}`);
+		}
+
+		this.log.info("Discord POST succeeded", { statusCode: res.status });
+		return true;
+	}
 }
 
 export const createDiscordWebhookClient = (


### PR DESCRIPTION
## 概要

`sendDiscordResponseStep` をリファクタリングし、既存のユーティリティを活用するようにしました。

## 変更内容

- `DiscordWebhookClient` に `postMessage` メソッドを追加 (POST リクエスト用)
- `sendDiscordResponseStep` を `DiscordWebhookClient` + `withRetry` で書き換え
- 手動の URL 構築、リトライループ、exponential backoff を削除
- テストを更新 (全124テスト合格)

Closes #83

🤖 Generated with [Claude Code](https://claude.ai/code)