### PR TITLE
fix: use correct input names for claude-code-action in issue triage workflow

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -28,9 +28,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.PAT_TOKEN }}
-          claude_args: "--model claude-opus-4-6 --max-turns 30"
-          allowed_tools: "Read,Glob,Grep,Write,Edit,Bash(gh issue:*),Bash(gh search:*),Bash(gh pr:*),Bash(gh label:*),Bash(git:*),Bash(npm run check),Bash(npm test)"
-          direct_prompt: |
+          claude_args: '--model claude-opus-4-6 --max-turns 30 --allowedTools "Read,Glob,Grep,Write,Edit,Bash(gh issue:*),Bash(gh search:*),Bash(gh pr:*),Bash(gh label:*),Bash(git:*),Bash(npm run check),Bash(npm test)"'
+          prompt: |
             You are an AI issue triage assistant for this repository. Analyze the newly opened issue and perform a comprehensive triage.
 
             ## Issue Details


### PR DESCRIPTION
## Summary

- `direct_prompt` → `prompt` に変更し、automationモードを有効化
- `allowed_tools` → `claude_args` 内の `--allowedTools` フラグに統合

`direct_prompt` と `allowed_tools` は `claude-code-action@v1` の有効なinputではなく、`prompt` が空扱いになりinteractiveモードにフォールバック → `@claude` メンションが見つからずワークフローがスキップされていた。

## Test plan

- [ ] mainマージ後、新しいテスト用issueを作成してワークフローが発火することを確認
- [ ] Claudeがトリアージコメントを投稿することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)