### PR TITLE
refactor: KV モジュールの ChatHistory 型を HistoryEntry に統一

### DIFF
--- a/src/clients/kv.test.ts
+++ b/src/clients/kv.test.ts
@@ -81,6 +81,21 @@ describe("KV class", () => {
 			expect(result[0].text).toBe("valid");
 		});
 
+		it("filters out entries with invalid role literals", async () => {
+			(mockKV.get as Mock).mockResolvedValue([
+				{ role: "user", text: "valid" },
+				{ role: "assistant", text: "invalid role literal" },
+				{ role: "model", text: "valid" },
+				{ role: "bot", text: "invalid role literal" },
+			]);
+
+			const result = await kv.getHistory();
+
+			expect(result).toHaveLength(2);
+			expect(result[0]).toEqual({ role: "user", text: "valid" });
+			expect(result[1]).toEqual({ role: "model", text: "valid" });
+		});
+
 		it("returns empty array when data is not an array", async () => {
 			(mockKV.get as Mock).mockResolvedValue({
 				role: "user",

--- a/src/clients/kv.ts
+++ b/src/clients/kv.ts
@@ -1,3 +1,4 @@
+import type { HistoryEntry } from "../types";
 import { getErrorMessage } from "../utils/errors";
 import { logger as defaultLogger, type Logger } from "../utils/logger";
 
@@ -14,11 +15,6 @@ type SheetInfo = {
 	description: string;
 };
 
-type ChatHistory = {
-	role: string;
-	text: string;
-};
-
 export class KV {
 	private kv: KVNamespace;
 	private log: Logger;
@@ -28,9 +24,9 @@ export class KV {
 		this.log = log ?? defaultLogger;
 	}
 
-	async saveHistory(history: { role: string; text: string }[]): Promise<void> {
+	async saveHistory(history: HistoryEntry[]): Promise<void> {
 		try {
-			const newHistory: ChatHistory[] = history.map(({ role, text }) => ({
+			const newHistory: HistoryEntry[] = history.map(({ role, text }) => ({
 				role,
 				text,
 			}));
@@ -46,10 +42,10 @@ export class KV {
 		}
 	}
 
-	async getHistory(): Promise<{ role: string; text: string }[]> {
+	async getHistory(): Promise<HistoryEntry[]> {
 		try {
 			// KVネイティブTTLにより期限切れデータは自動的にnullになる
-			const parsedHistory = await this.kv.get<ChatHistory[]>(
+			const parsedHistory = await this.kv.get<HistoryEntry[]>(
 				HISTORY_KEY,
 				"json",
 			);
@@ -62,10 +58,10 @@ export class KV {
 
 			return parsedHistory
 				.filter(
-					(h): h is ChatHistory =>
+					(h): h is HistoryEntry =>
 						!!h &&
 						typeof h === "object" &&
-						typeof h.role === "string" &&
+						(h.role === "user" || h.role === "model") &&
 						typeof h.text === "string",
 				)
 				.map(({ role, text }) => ({ role, text }));


### PR DESCRIPTION
## Summary
- `src/clients/kv.ts` のローカル `ChatHistory` 型（`role: string`）を削除し、`src/types.ts` の `HistoryEntry` 型（`role: "user" | "model"`）に統一
- `saveHistory()` / `getHistory()` の型を `HistoryEntry[]` に変更
- ランタイムバリデーションを `typeof h.role === "string"` から `(h.role === "user" || h.role === "model")` に強化
- 不正な role リテラル（`"assistant"`, `"bot"` 等）のフィルタリングテストを追加

Fixes #103

## Test plan
- [x] `npm test` — 既存テスト 123 件 + 新規テスト全パス（kv.test.ts: 13 → 14 テスト）
- [x] `npm run check` — Biome lint/format パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)