### PR TITLE
feat: add auto-implementation trigger from issue triage

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,5 +38,5 @@ jobs:
           github_token: ${{ secrets.PAT_TOKEN }}
           additional_permissions: |
             actions: read
-          claude_args: "--model claude-opus-4-6"
+          claude_args: '--model claude-opus-4-6 --max-turns 50 --allowedTools "Read,Glob,Grep,Write,Edit,Bash(gh issue:*),Bash(gh search:*),Bash(gh pr:*),Bash(gh label:*),Bash(git:*),Bash(npm run check),Bash(npm test)"'
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -138,7 +138,7 @@ jobs:
 
             Adapt the sections based on the issue type (bug vs feature vs question etc).
 
-            ### Step 7: Auto-fix PR (Conditional)
+            ### Step 7a: Auto-fix PR (Conditional)
             ONLY attempt this if ALL conditions are met:
             - The issue type is `bug` or `enhancement`
             - The fix is obviously simple (2 files or fewer, ~20 lines or fewer)
@@ -156,4 +156,36 @@ jobs:
                ```
             6. If checks fail, discard changes and note in the triage comment that auto-fix was attempted but could not be completed.
 
-            If conditions are NOT met, skip this step entirely (this is expected for most issues).
+            If conditions are NOT met, skip this step and proceed to Step 7b.
+
+            ### Step 7b: Trigger @claude Implementation (Conditional)
+            If Step 7a was NOT executed, evaluate whether this issue is suitable for automated implementation via `@claude`.
+
+            ONLY trigger this if ALL conditions are met:
+            - The issue type is `bug`, `enhancement`, or `feature`
+            - Complexity is S or M
+            - The Implementation Approach (or Root Cause Hypothesis for bugs) is concrete: specific target files, functions, and changes are identified
+            - The issue is NOT a duplicate
+            - Step 7a was NOT executed
+
+            If ALL conditions are met, post a comment using `gh issue comment` to trigger the `claude.yml` workflow:
+
+            ```
+            gh issue comment ${{ github.event.issue.number }} --body "@claude 上記のトリアージ分析に基づいて、このissueを実装してください。
+
+            ## 実装指示
+            <トリアージ分析のImplementation ApproachまたはRoot Cause Hypothesisから導出した具体的な実装手順をここに記述>
+
+            ## 対象ファイル
+            <トリアージで特定したファイルリストをここに記述>
+
+            ## 完了条件
+            - 実装が完了していること
+            - \`npm run check\` がパスすること
+            - \`npm test\` がパスすること
+            - ドラフトPRを作成すること"
+            ```
+
+            IMPORTANT: The `@claude` comment MUST be posted using the PAT_TOKEN (already configured as github_token) so that the comment is created by the `henzai` user, which is required to trigger the `claude.yml` workflow.
+
+            If conditions are NOT met, skip this step entirely (this is expected for questions, documentation issues, complex issues, or duplicates).


### PR DESCRIPTION
## Summary
- **claude.yml**: `claude_args` に `--max-turns 50` と `--allowedTools` を追加。`gh pr create` や `git push` 等の Bash コマンドが事前承認され、ワンクリック承認なしで直接PR作成が可能に
- **issue-triage.yml**: Step 7 を 7a/7b に分離。7a は既存の直接auto-fix、7b はトリアージでプランが十分に練れた S/M issueに対して `@claude` コメントを投稿し `claude.yml` で自動実装を開始

## フロー
1. `issue-triage.yml` が `issues:opened` でトリアージ実行
2. Step 7b で `gh issue comment` (PAT_TOKEN使用) → `@claude` コメントを henzai として投稿
3. `issue_comment` イベント発火 → `claude.yml` がトリガー
4. Claude が実装 → draft PR 作成

## Test plan
- [ ] YAML構文が正しいこと
- [ ] テスト用issueを作成してトリアージが正常に実行されることを確認
- [ ] プランが十分な場合に `@claude` コメントが投稿されることを確認
- [ ] `claude.yml` がトリガーされ実装が開始されることを確認
- [ ] draft PR が直接作成されること（ワンクリック承認なし）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)