### PR TITLE
fix: claude.yml に prompt 追加でドラフトPR自動作成を保証

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,7 +40,7 @@ jobs:
             actions: read
           claude_args: '--model claude-opus-4-6 --max-turns 50 --allowedTools "Read,Glob,Grep,Write,Edit,Bash(gh issue:*),Bash(gh search:*),Bash(gh pr:*),Bash(gh label:*),Bash(git:*),Bash(npm run check),Bash(npm test)"'
           prompt: |
-            issueに対する実装タスクを完了した場合、必ず以下の手順でドラフトPRを作成してください:
+            実装タスクを完了した場合、必ず以下の手順でドラフトPRを作成してください:
 
             1. 実装が完了したら `npm run check` と `npm test` を実行して検証する
             2. 変更をコミット＆プッシュする


### PR DESCRIPTION
## Summary
- `claude.yml` に `prompt` フィールドを追加し、issueの実装完了時に必ず `gh pr create --draft` を実行するよう指示
- `--allowedTools` は権限を与えるだけで、PR作成の指示にはならないため、ベースプロンプトで明示的に指示する必要があった

## 背景
PR #108 で `--allowedTools` に `Bash(gh pr:*)` を追加したが、`@claude` コメントに「PRを作成してください」と書かれていない場合、Claude はPR作成をスキップし「Create PR →」リンクが表示されるだけだった (#106)

## Test plan
- [ ] テスト用issueを作成し `@claude` コメント（PR作成指示なし）でトリガー
- [ ] Claude が自動的にドラフトPRを作成することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)