### PR TITLE
fix(ci): add cf-typegen to Claude Code Action allowedTools

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,7 +38,7 @@ jobs:
           github_token: ${{ secrets.PAT_TOKEN }}
           additional_permissions: |
             actions: read
-          claude_args: '--model claude-opus-4-6 --max-turns 50 --allowedTools "Read,Glob,Grep,Write,Edit,Bash(gh issue:*),Bash(gh search:*),Bash(gh pr:*),Bash(gh label:*),Bash(git:*),Bash(npm run check),Bash(npm test)"'
+          claude_args: '--model claude-opus-4-6 --max-turns 50 --allowedTools "Read,Glob,Grep,Write,Edit,Bash(gh issue:*),Bash(gh search:*),Bash(gh pr:*),Bash(gh label:*),Bash(git:*),Bash(npm run check),Bash(npm test),Bash(npm run cf-typegen)"'
           prompt: |
             実装タスクを完了した場合、必ず以下の手順でドラフトPRを作成してください:
 


### PR DESCRIPTION
## Summary

- Claude Code Action の `allowedTools` に `Bash(npm run cf-typegen)` を追加

## 背景

Renovate PR #118（wrangler 4.64.0 → 4.65.0）で CI の `typecheck` ジョブが失敗した。wrangler のバージョンアップにより `npm run cf-typegen` が生成する `worker-configuration.d.ts` のコメントが変わったことが原因。

`renovate-autofix.yml` が `@claude` コメントを投稿し Claude Code Action がトリガーされたが、`allowedTools` に `npm run cf-typegen` が含まれていなかったため、Claude は修復に必要なコマンドを実行できず1ターンで終了した。

## 変更内容

`.github/workflows/claude.yml` の `allowedTools` に `Bash(npm run cf-typegen)` を追加し、Claude Code Action が型定義の再生成を行えるようにした。

## Test plan

- [ ] CI が通ることを確認
- [ ] 次回 wrangler 等のアップデートで `typecheck` が失敗した際に、Claude Code Action が `npm run cf-typegen` を実行して修復できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)