### PR TITLE
fix(ci): simplify claude.yml prompt and add explicit commit/push instructions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,11 +40,6 @@ jobs:
             actions: read
           claude_args: '--model claude-opus-4-6 --max-turns 50 --allowedTools "Read,Glob,Grep,Write,Edit,Bash(gh issue:*),Bash(gh search:*),Bash(gh pr:*),Bash(gh label:*),Bash(git:*),Bash(npm run check),Bash(npm test),Bash(npm run cf-typegen)"'
           prompt: |
-            実装タスクを完了した場合、必ず以下の手順でドラフトPRを作成してください:
-
-            1. 実装が完了したら `npm run check` と `npm test` を実行して検証する
-            2. 変更をコミット＆プッシュする
-            3. `gh pr create --draft` でドラフトPRを作成する（PRボディには `Fixes #<issue-number>` を含める）
-
-            PRの作成は必須です。「Create PR →」リンクに頼らず、必ず自分で `gh pr create` を実行してください。
+            @claude メンション内の指示に従って作業を実行してください。
+            コード変更を行った場合は `npm run check` と `npm test` で検証してください。
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -193,7 +193,9 @@ jobs:
             - 実装が完了していること
             - \`npm run check\` がパスすること
             - \`npm test\` がパスすること
-            - ドラフトPRを作成すること"
+            - \`main\` ブランチから新しいブランチを作成すること（\`git fetch origin && git checkout -b <branch> origin/main\`）
+            - 変更をコミット＆プッシュすること
+            - \`gh pr create --draft\` でドラフトPRを作成すること（PRボディには \`Fixes #<issue-number>\` を含める）"
             ```
 
             IMPORTANT: The `@claude` comment MUST be posted using the PAT_TOKEN (already configured as github_token) so that the comment is created by the `henzai` user, which is required to trigger the `claude.yml` workflow.

--- a/.github/workflows/renovate-autofix.yml
+++ b/.github/workflows/renovate-autofix.yml
@@ -114,6 +114,7 @@ jobs:
               '4. Run `npm run check` to fix any formatting/lint issues',
               '5. Run `npm test` to verify tests pass',
               '6. If `npm run cf-typegen` generates changed types, include those changes',
+              '7. Commit and push the fixes to this PR branch',
             ].join('\n');
 
             await github.rest.issues.createComment({


### PR DESCRIPTION
## Summary

- **claude.yml**: Simplified prompt to minimal "follow @claude instructions + run checks" instead of conditional instructions that caused Claude to do nothing (#125)
- **renovate-autofix.yml**: Added step 7 "Commit and push the fixes to this PR branch" so Claude commits after fixing CI failures
- **issue-triage.yml**: Replaced vague "create a draft PR" with explicit branch creation (`git fetch origin && git checkout -b <branch> origin/main`), commit/push, and `gh pr create --draft` instructions

## Test plan

- [ ] Trigger `@claude` on Issue #125 and verify Claude executes multiple turns and creates a draft PR
- [ ] Verify Renovate auto-fix workflow includes commit/push step in the generated `@claude` comment
- [ ] Verify issue triage `@claude` comment includes explicit branch/commit/PR instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)