### PR TITLE
feat: Worker エラーの GitHub Issues 自動報告

### DIFF
--- a/src/clients/github.test.ts
+++ b/src/clients/github.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createGitHubIssueClient,
+	type ErrorReport,
+	GitHubIssueClient,
+} from "./github";
+
+describe("GitHubIssueClient", () => {
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	const sampleReport: ErrorReport = {
+		errorMessage: "Gemini API failed with status 500",
+		requestId: "req-123",
+		workflowId: "wf-456",
+		step: "streamGeminiAndEditDiscord",
+		durationMs: 5000,
+		stepCount: 2,
+		timestamp: "2026-02-14T12:00:00.000Z",
+	};
+
+	describe("generateFingerprint", () => {
+		it("replaces UUIDs with placeholder", () => {
+			const client = new GitHubIssueClient("token");
+			const result = client.generateFingerprint(
+				"Error for request 550e8400-e29b-41d4-a716-446655440000",
+			);
+			expect(result).toBe("Error for request <UUID>");
+		});
+
+		it("replaces timestamps with placeholder", () => {
+			const client = new GitHubIssueClient("token");
+			const result = client.generateFingerprint(
+				"Error at 2026-02-14T12:00:00.000Z",
+			);
+			expect(result).toBe("Error at <TIMESTAMP>");
+		});
+
+		it("replaces numbers with placeholder", () => {
+			const client = new GitHubIssueClient("token");
+			const result = client.generateFingerprint(
+				"Failed with status 500 after 3 retries",
+			);
+			expect(result).toBe("Failed with status <N> after <N> retries");
+		});
+
+		it("replaces hex strings with placeholder", () => {
+			const client = new GitHubIssueClient("token");
+			const result = client.generateFingerprint(
+				"Error for hash abcdef0123456789",
+			);
+			expect(result).toBe("Error for hash <HEX>");
+		});
+
+		it("normalizes complex error messages consistently", () => {
+			const client = new GitHubIssueClient("token");
+			const msg1 =
+				"Gemini API error: status 503 at 2026-02-14T10:00:00Z request abc12345";
+			const msg2 =
+				"Gemini API error: status 429 at 2026-02-14T15:30:00Z request def67890";
+			expect(client.generateFingerprint(msg1)).toBe(
+				client.generateFingerprint(msg2),
+			);
+		});
+	});
+
+	describe("createIssue", () => {
+		it("creates an issue successfully", async () => {
+			const mockFetch = vi.fn().mockResolvedValue({
+				ok: true,
+				status: 201,
+			});
+			globalThis.fetch = mockFetch;
+
+			const client = new GitHubIssueClient("test-token");
+			const result = await client.createIssue(sampleReport, "test-fingerprint");
+
+			expect(result).toBe(true);
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+
+			const [url, options] = mockFetch.mock.calls[0];
+			expect(url).toBe(
+				"https://api.github.com/repos/henzai/yangbingyibot/issues",
+			);
+			expect(options.method).toBe("POST");
+			expect(options.headers.Authorization).toBe("Bearer test-token");
+
+			const body = JSON.parse(options.body);
+			expect(body.title).toContain("[Auto] Worker Error:");
+			expect(body.title).toContain("Gemini API failed");
+			expect(body.labels).toEqual(["bug", "auto-reported"]);
+			expect(body.body).toContain("test-fingerprint");
+			expect(body.body).toContain("req-123");
+		});
+
+		it("truncates long error messages in the title", async () => {
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				status: 201,
+			});
+
+			const client = new GitHubIssueClient("test-token");
+			const longReport = {
+				...sampleReport,
+				errorMessage: "A".repeat(200),
+			};
+			await client.createIssue(longReport, "fp");
+
+			const body = JSON.parse(
+				(globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
+			);
+			// Title should be truncated: "[Auto] Worker Error: " + 80 chars
+			expect(body.title.length).toBeLessThanOrEqual(
+				"[Auto] Worker Error: ".length + 80,
+			);
+		});
+
+		it("returns false on API error", async () => {
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 403,
+			});
+
+			const client = new GitHubIssueClient("test-token");
+			const result = await client.createIssue(sampleReport, "fp");
+
+			expect(result).toBe(false);
+		});
+
+		it("returns false on network error", async () => {
+			globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+			const client = new GitHubIssueClient("test-token");
+			const result = await client.createIssue(sampleReport, "fp");
+
+			expect(result).toBe(false);
+		});
+
+		it("omits step row from body when step is undefined", async () => {
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				status: 201,
+			});
+
+			const client = new GitHubIssueClient("test-token");
+			const reportWithoutStep = { ...sampleReport, step: undefined };
+			await client.createIssue(reportWithoutStep, "fp");
+
+			const body = JSON.parse(
+				(globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
+			);
+			expect(body.body).not.toContain("**Step**");
+		});
+	});
+
+	describe("isDuplicate", () => {
+		it("returns true when matching issues exist", async () => {
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({ total_count: 1 }),
+			});
+
+			const client = new GitHubIssueClient("test-token");
+			const result = await client.isDuplicate("test-fingerprint");
+
+			expect(result).toBe(true);
+
+			const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+				.calls[0];
+			expect(url).toContain("search/issues");
+			expect(url).toContain("auto-reported");
+			expect(url).toContain("test-fingerprint");
+		});
+
+		it("returns false when no matching issues exist", async () => {
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({ total_count: 0 }),
+			});
+
+			const client = new GitHubIssueClient("test-token");
+			const result = await client.isDuplicate("test-fingerprint");
+
+			expect(result).toBe(false);
+		});
+
+		it("returns false (fail-open) on API error", async () => {
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 403,
+			});
+
+			const client = new GitHubIssueClient("test-token");
+			const result = await client.isDuplicate("test-fingerprint");
+
+			expect(result).toBe(false);
+		});
+
+		it("returns false (fail-open) on network error", async () => {
+			globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+			const client = new GitHubIssueClient("test-token");
+			const result = await client.isDuplicate("test-fingerprint");
+
+			expect(result).toBe(false);
+		});
+	});
+
+	describe("createGitHubIssueClient", () => {
+		it("creates a new GitHubIssueClient instance", () => {
+			const client = createGitHubIssueClient("test-token");
+			expect(client).toBeInstanceOf(GitHubIssueClient);
+		});
+	});
+});

--- a/src/clients/github.ts
+++ b/src/clients/github.ts
@@ -1,0 +1,152 @@
+import { getErrorMessage } from "../utils/errors";
+import { logger as defaultLogger, type Logger } from "../utils/logger";
+
+const GITHUB_API_BASE = "https://api.github.com";
+const REPO_OWNER = "henzai";
+const REPO_NAME = "yangbingyibot";
+
+export interface ErrorReport {
+	errorMessage: string;
+	requestId: string;
+	workflowId: string;
+	step?: string;
+	durationMs: number;
+	stepCount: number;
+	timestamp: string;
+}
+
+export class GitHubIssueClient {
+	private token: string;
+	private log: Logger;
+
+	constructor(token: string, log?: Logger) {
+		this.token = token;
+		this.log = log ?? defaultLogger;
+	}
+
+	/**
+	 * Generate a fingerprint from an error message by removing dynamic elements.
+	 * This allows grouping similar errors together for deduplication.
+	 */
+	generateFingerprint(errorMessage: string): string {
+		return errorMessage
+			.replace(
+				/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
+				"<UUID>",
+			)
+			.replace(/\b[0-9a-f]{8,}\b/gi, "<HEX>")
+			.replace(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[.\dZ]*/g, "<TIMESTAMP>")
+			.replace(/\d+/g, "<N>");
+	}
+
+	/**
+	 * Check if a GitHub Issue with the same fingerprint already exists (open).
+	 * Fail-open: returns false on any error so that a new issue is created.
+	 */
+	async isDuplicate(fingerprint: string): Promise<boolean> {
+		try {
+			const query = encodeURIComponent(
+				`repo:${REPO_OWNER}/${REPO_NAME} is:issue is:open label:auto-reported "${fingerprint}"`,
+			);
+			const res = await fetch(
+				`${GITHUB_API_BASE}/search/issues?q=${query}&per_page=1`,
+				{
+					headers: {
+						Authorization: `Bearer ${this.token}`,
+						Accept: "application/vnd.github+json",
+						"User-Agent": "yangbingyibot-error-reporter",
+					},
+				},
+			);
+
+			if (!res.ok) {
+				this.log.warn("GitHub issue search failed", {
+					statusCode: res.status,
+				});
+				return false;
+			}
+
+			const data = (await res.json()) as { total_count: number };
+			return data.total_count > 0;
+		} catch (error) {
+			this.log.warn("GitHub issue search error (fail-open)", {
+				error: getErrorMessage(error),
+			});
+			return false;
+		}
+	}
+
+	/**
+	 * Create a GitHub Issue for an error report.
+	 * Non-fatal: logs warnings but does not throw on failure.
+	 */
+	async createIssue(
+		report: ErrorReport,
+		fingerprint: string,
+	): Promise<boolean> {
+		try {
+			const title = `[Auto] Worker Error: ${report.errorMessage.slice(0, 80)}`;
+
+			const body = [
+				"## Error Details",
+				"",
+				"| Field | Value |",
+				"| --- | --- |",
+				`| **Error** | \`${report.errorMessage}\` |`,
+				`| **Request ID** | \`${report.requestId}\` |`,
+				`| **Workflow ID** | \`${report.workflowId}\` |`,
+				...(report.step ? [`| **Step** | \`${report.step}\` |`] : []),
+				`| **Duration** | ${report.durationMs}ms |`,
+				`| **Steps Completed** | ${report.stepCount} |`,
+				`| **Timestamp** | ${report.timestamp} |`,
+				"",
+				"## Fingerprint",
+				"",
+				`\`${fingerprint}\``,
+				"",
+				"---",
+				"*This issue was automatically created by the error monitoring system.*",
+			].join("\n");
+
+			const res = await fetch(
+				`${GITHUB_API_BASE}/repos/${REPO_OWNER}/${REPO_NAME}/issues`,
+				{
+					method: "POST",
+					headers: {
+						Authorization: `Bearer ${this.token}`,
+						Accept: "application/vnd.github+json",
+						"User-Agent": "yangbingyibot-error-reporter",
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify({
+						title,
+						body,
+						labels: ["bug", "auto-reported"],
+					}),
+				},
+			);
+
+			if (!res.ok) {
+				this.log.warn("GitHub issue creation failed", {
+					statusCode: res.status,
+				});
+				return false;
+			}
+
+			this.log.info("GitHub issue created successfully");
+			return true;
+		} catch (error) {
+			this.log.warn("GitHub issue creation error", {
+				error: getErrorMessage(error),
+			});
+			return false;
+		}
+	}
+}
+
+export const createGitHubIssueClient = (
+	token: string,
+	log?: Logger,
+): GitHubIssueClient => {
+	return new GitHubIssueClient(token, log);
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,4 +11,5 @@ export type Bindings = {
 	sushanshan_bot: KVNamespace;
 	ANSWER_QUESTION_WORKFLOW: Workflow<WorkflowParams>;
 	METRICS?: AnalyticsEngineDataset;
+	GITHUB_TOKEN?: string;
 };


### PR DESCRIPTION
## Summary

- Workflow catch ブロックにエラー発生時の GitHub Issues 自動報告機能を追加
- `GitHubIssueClient` クラスを新規作成（fingerprint 生成、重複検索、Issue 作成）
- KV（1時間TTL）+ GitHub Issues 検索の2層重複排除で同一エラーの重複 Issue を防止
- `GITHUB_TOKEN` 未設定時は安全にスキップ、報告処理自体のエラーも非致命的として処理

closes #125

## Test plan

- [x] `npm run check` が通ることを確認
- [x] `npm test` で全163テストが通ることを確認
- [ ] デプロイ後、意図的にエラーを発生させ GitHub Issues に自動作成されることを確認
- [ ] 同じエラーを再度発生させ、重複 Issue が作成されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)