### PR TITLE
chore: update summarize model to gemini-2.5-flash-lite

### DIFF
--- a/src/workflows/answerQuestionWorkflow.ts
+++ b/src/workflows/answerQuestionWorkflow.ts
@@ -112,7 +112,7 @@ const MIN_CHUNK_SIZE = 50;
 const THINKING_EDIT_INTERVAL_MS = 1000;
 const THINKING_MIN_CHUNK_SIZE = 200;
 
-const SUMMARIZE_MODEL = "gemini-2.0-flash-lite";
+const SUMMARIZE_MODEL = "gemini-2.5-flash-lite";
 const THINKING_FALLBACK = "考え中...";
 
 export async function summarizeThinking(


### PR DESCRIPTION
## 概要

要約処理（`summarizeThinking`）で使うGeminiモデルを更新。

## 変更内容

- `SUMMARIZE_MODEL`: `gemini-2.0-flash-lite` → `gemini-2.5-flash-lite`

## 背景

2026年7月時点で `gemini-2.5-flash-lite`（$0.10/$0.40 per 1M tokens）はGeminiモデル中で最安かつ、旧 `2.0-flash-lite` より世代が新しく性能も向上している。要約は軽量タスクのためLite帯で十分。

## メインモデルについて

メイン回答生成の `gemini-3-flash-preview` は既に最新の「Gemini 3 Flash」であり、安定版の無印ID（`gemini-3-flash`）が公開されているか未確認のため本PRでは変更していない。安定版が確認でき次第、別途対応する。

## 検証

- [x] `npm run check` パス
- [x] `npm test` パス（173 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)