### PR TITLE
feat: シートCSVを圧縮してGeminiの入力トークンを24.5%削減

### DIFF
--- a/src/clients/spreadSheet.test.ts
+++ b/src/clients/spreadSheet.test.ts
@@ -90,8 +90,9 @@ describe("spreadSheet", () => {
 
 			const result = await getSheetData(validServiceAccount, mockLogger);
 
+			// sheetInfoはcompactSheetCsvを通るためTSVで返る
 			expect(result).toEqual({
-				sheetInfo: "col1,col2\nval1,val2",
+				sheetInfo: "col1\tcol2\nval1\tval2",
 				description: "Bot description",
 			});
 		});

--- a/src/clients/spreadSheet.ts
+++ b/src/clients/spreadSheet.ts
@@ -2,6 +2,7 @@ import GoogleAuth, {
 	type GoogleKey,
 } from "cloudflare-workers-and-google-oauth";
 import { GoogleSpreadsheet } from "google-spreadsheet";
+import { compactSheetCsv } from "../utils/compactSheet";
 import { getErrorMessage } from "../utils/errors";
 import { logger as defaultLogger, type Logger } from "../utils/logger";
 
@@ -85,7 +86,14 @@ async function fetchSheetInfo(
 			throw new Error("Sheet returned empty CSV data");
 		}
 
-		return csvContent;
+		// CSVはGeminiへの入力トークンの大半を占めるため、渡す前に圧縮する
+		const compacted = compactSheetCsv(csvContent);
+		log.info("Sheet CSV compacted", {
+			originalChars: csvContent.length,
+			compactedChars: compacted.length,
+		});
+
+		return compacted;
 	} catch (error) {
 		log.error("Failed to download sheet as CSV", {
 			error: getErrorMessage(error),

--- a/src/utils/compactSheet.test.ts
+++ b/src/utils/compactSheet.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { compactSheetCsv } from "./compactSheet";
+
+// 先頭3行はメタ行・列説明行・ヘッダ行として無条件に保持されるため、
+// 行除去の検証にはダミーのヘッダを積んでからデータ行を並べる
+const HEADER = [
+	'"meta","",""',
+	'"説明A","説明B","説明C"',
+	'"id","name","team"',
+].join("\n");
+
+describe("compactSheetCsv", () => {
+	it("converts CSV to TSV", () => {
+		const result = compactSheetCsv(`${HEADER}\n"1","闫明筠","SII"`);
+
+		expect(result.split("\n")).toEqual([
+			"meta\t\t",
+			"説明A\t説明B\t説明C",
+			"id\tname\tteam",
+			"1\t闫明筠\tSII",
+		]);
+	});
+
+	it("drops columns that are empty in every row", () => {
+		const csv = [
+			'"meta","","",""',
+			'"説明A","","説明C",""',
+			'"id","","team",""',
+			'"1","","SII",""',
+		].join("\n");
+
+		// 2列目と4列目は全行空なので消える
+		expect(compactSheetCsv(csv).split("\n")).toEqual([
+			"meta\t",
+			"説明A\t説明C",
+			"id\tteam",
+			"1\tSII",
+		]);
+	});
+
+	it("drops rows holding fewer than two non-empty cells", () => {
+		const csv = [
+			HEADER,
+			'"1","闫明筠","SII"',
+			'"","730",""',
+			'"2","莫寒","TII"',
+		].join("\n");
+
+		const result = compactSheetCsv(csv);
+
+		expect(result).not.toContain("730");
+		expect(result.split("\n")).toHaveLength(5);
+	});
+
+	it("keeps the first three rows even when sparse", () => {
+		const csv = [
+			'"2026/07/26","",""',
+			'"","",""',
+			'"id","",""',
+			'"","",""',
+		].join("\n");
+
+		const lines = compactSheetCsv(csv).split("\n");
+
+		// 先頭3行は保持され、4行目のスカスカな行だけが落ちる
+		expect(lines).toHaveLength(3);
+		expect(lines[0]).toContain("2026/07/26");
+		expect(lines[2]).toContain("id");
+	});
+
+	it("preserves commas inside quoted fields", () => {
+		const csv = `${HEADER}\n"1","Yan, MingJun","SII"`;
+
+		expect(compactSheetCsv(csv).split("\n")[3]).toBe("1\tYan, MingJun\tSII");
+	});
+
+	it("unescapes doubled quotes inside quoted fields", () => {
+		const csv = `${HEADER}\n"1","She said ""hi""","SII"`;
+
+		expect(compactSheetCsv(csv).split("\n")[3]).toBe('1\tShe said "hi"\tSII');
+	});
+
+	it("replaces tabs inside cells so they cannot break the TSV layout", () => {
+		const csv = `${HEADER}\n"1","Yan\tMingJun","SII"`;
+
+		const columns = compactSheetCsv(csv).split("\n")[3].split("\t");
+
+		expect(columns).toHaveLength(3);
+		expect(columns[1]).toBe("Yan MingJun");
+	});
+
+	it("trims surrounding whitespace in cells", () => {
+		const csv = `${HEADER}\n"1","  闫明筠  ","SII"`;
+
+		expect(compactSheetCsv(csv).split("\n")[3]).toBe("1\t闫明筠\tSII");
+	});
+
+	it("handles a final row without a trailing newline", () => {
+		const csv = `${HEADER}\n"1","闫明筠","SII"`;
+
+		expect(compactSheetCsv(csv).split("\n")).toHaveLength(4);
+	});
+
+	it("returns an empty string for empty input", () => {
+		expect(compactSheetCsv("")).toBe("");
+	});
+});

--- a/src/utils/compactSheet.ts
+++ b/src/utils/compactSheet.ts
@@ -1,0 +1,88 @@
+// スプレッドシートのCSVはGeminiへの入力トークンの大半を占めるため、
+// 意味を落とさずに削れる分を落としてから渡す。
+// 内訳: 全行が空の列を除去、情報量のない行を除去、CSV -> TSV。
+
+// 先頭から保持する行数（メタ行・列説明行・ヘッダ行）
+const PRESERVED_HEADER_ROWS = 3;
+
+// これ未満の非空セルしか持たない行は情報量がないとみなして除去する。
+// 列位置や見出し名に依存しないため、シートのレイアウト変更に強い。
+const MIN_NON_EMPTY_CELLS = 2;
+
+function parseCsv(csv: string): string[][] {
+	const rows: string[][] = [];
+	let row: string[] = [];
+	let cell = "";
+	let inQuotes = false;
+
+	for (let i = 0; i < csv.length; i++) {
+		const char = csv[i];
+
+		if (inQuotes) {
+			if (char === '"') {
+				// 連続する二重引用符はエスケープされた引用符
+				if (csv[i + 1] === '"') {
+					cell += '"';
+					i++;
+				} else {
+					inQuotes = false;
+				}
+			} else {
+				cell += char;
+			}
+			continue;
+		}
+
+		if (char === '"') {
+			inQuotes = true;
+		} else if (char === ",") {
+			row.push(cell);
+			cell = "";
+		} else if (char === "\n") {
+			row.push(cell);
+			rows.push(row);
+			row = [];
+			cell = "";
+		} else if (char !== "\r") {
+			cell += char;
+		}
+	}
+
+	// 末尾に改行がない場合の最終行
+	if (cell !== "" || row.length > 0) {
+		row.push(cell);
+		rows.push(row);
+	}
+
+	return rows;
+}
+
+// TSVの区切りを壊さないよう、セル内の制御文字を空白に潰す
+function sanitizeCell(value: string | undefined): string {
+	return (value ?? "").replace(/[\t\r\n]+/g, " ").trim();
+}
+
+export function compactSheetCsv(csv: string): string {
+	const rows = parseCsv(csv).map((row) => row.map(sanitizeCell));
+	if (rows.length === 0) return "";
+
+	const columnCount = Math.max(...rows.map((row) => row.length));
+
+	// 全行にわたって空の列は情報を持たないので落とす
+	const liveColumns: number[] = [];
+	for (let column = 0; column < columnCount; column++) {
+		if (rows.some((row) => row[column])) {
+			liveColumns.push(column);
+		}
+	}
+
+	const keptRows = rows.filter((row, index) => {
+		if (index < PRESERVED_HEADER_ROWS) return true;
+		const nonEmpty = row.filter(Boolean).length;
+		return nonEmpty >= MIN_NON_EMPTY_CELLS;
+	});
+
+	return keptRows
+		.map((row) => liveColumns.map((column) => row[column] ?? "").join("\t"))
+		.join("\n");
+}


### PR DESCRIPTION
## 背景

Gemini APIのコストを調べたところ、**入力トークンが全体の約95%**を占めていることが分かりました。原因はスプレッドシートのCSVを毎リクエスト丸ごと渡していることです。

実データ（999行 × 53列）を計測した結果:

| 項目 | 実測 |
|---|---:|
| CSVサイズ | 499,630 bytes |
| 推定トークン数 | **約145,600** |
| 空セル | 31,886 / 52,947（60.2%） |

1質問あたり約 $0.077、1,000質問で約 $76.60 という規模でした。

## 変更内容

`compactSheetCsv()` を追加し、`fetchSheetInfo` の返却前に通します。意味を落とさずに削れる分だけを落とします。

1. **全行が空の列を除去** — 48〜52列目の5本。1セルも埋まっていないので無条件に安全
2. **情報量のない行を除去** — 非空セルが2個未満の行。実データでは264行あり、すべて「4列目に `730` が入っているだけ」の残骸でした
3. **CSV → TSV** — 引用符とセパレータのオーバーヘッドを削減

行の除去条件は列位置や見出し名ではなく**非空セル数**で判定しているため、シートのレイアウトが変わっても壊れません。先頭3行（メタ行・列説明行・ヘッダ行）は列の意味をモデルに伝えているので無条件に保持します。

## 効果（実データで計測）

| | 変更前 | 変更後 |
|---|---:|---:|
| 文字数 | 388,226 | 263,150 |
| 行数 | 999 | 735 |
| 列数 | 53 | 48 |
| **推定トークン数** | **145,588** | **109,852（-24.5%）** |

1,000質問あたり **$76.60 → $58.73（-$17.87）**。

## 検討したが採用しなかった案

空セルが60%あるため疎な形式が有利かと考えましたが、実測すると**逆効果**でした。列名を全行で繰り返すコストが空セルのセパレータより大きいためです。

| 案 | 推定トークン | 差 |
|---|---:|---:|
| 疎な `key:value` 形式 | 169,639 | +17% |
| JSON Lines（空欄省略） | 182,192 | +25% |
| 充填率10%未満の列も除去 | 106,003 | -27% |

充填率10%未満の列の除去は、-24.5%から2%しか稼げないのに16列を捨てるため、情報損失に見合わないと判断しました。

## 確認事項

- [x] `npm run check`
- [x] `npm test`（183件通過）
- [ ] **デプロイ後、TSV形式での回答品質を目視確認したい**（TSVはLLMが扱える形式なのでリスクは低いと見ていますが、モデルに渡る形式が変わるため）

なお圧縮前後の文字数をログに出しているので、本番の実CSVでの削減量も追えます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)