### PR TITLE
feat: Geminiのトークン使用量とキャッシュヒット率をログに出す

### DIFF
--- a/src/clients/gemini.test.ts
+++ b/src/clients/gemini.test.ts
@@ -387,6 +387,123 @@ describe("GeminiClient", () => {
 		});
 	});
 
+	describe("token usage logging", () => {
+		const makeLogger = () => ({
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			debug: vi.fn(),
+			withContext: vi.fn().mockReturnThis(),
+		});
+
+		const usageOf = (log: ReturnType<typeof makeLogger>) =>
+			log.info.mock.calls.find(
+				([message]) => message === "Gemini token usage",
+			)?.[1];
+
+		it("logs the token breakdown from a non-streaming response", async () => {
+			mockGenerateContent.mockResolvedValue({
+				candidates: [{ content: { parts: [{ text: "AI response" }] } }],
+				usageMetadata: {
+					promptTokenCount: 110000,
+					cachedContentTokenCount: 88000,
+					thoughtsTokenCount: 800,
+					candidatesTokenCount: 400,
+					totalTokenCount: 111200,
+				},
+			});
+
+			const log = makeLogger();
+			await new GeminiClient("test-api-key", [], log).ask("q", "s", "d");
+
+			expect(usageOf(log)).toMatchObject({
+				mode: "generate",
+				promptTokens: 110000,
+				cachedTokens: 88000,
+				cachedRatio: 0.8,
+				thoughtsTokens: 800,
+				candidatesTokens: 400,
+				totalTokens: 111200,
+			});
+		});
+
+		it("logs usage carried on the final streaming chunk", async () => {
+			const mockStream = (async function* () {
+				yield { candidates: [{ content: { parts: [{ text: "Hello" }] } }] };
+				yield {
+					candidates: [{ content: { parts: [{ text: " world" }] } }],
+					usageMetadata: {
+						promptTokenCount: 1000,
+						cachedContentTokenCount: 250,
+						totalTokenCount: 1200,
+					},
+				};
+			})();
+			mockGenerateContentStream.mockResolvedValue(mockStream);
+
+			const log = makeLogger();
+			await new GeminiClient("test-api-key", [], log).askStream(
+				"q",
+				"s",
+				"d",
+				async () => {},
+			);
+
+			expect(usageOf(log)).toMatchObject({
+				mode: "stream",
+				promptTokens: 1000,
+				cachedTokens: 250,
+				cachedRatio: 0.25,
+			});
+		});
+
+		it("reports a zero cache ratio when nothing was cached", async () => {
+			mockGenerateContent.mockResolvedValue({
+				candidates: [{ content: { parts: [{ text: "AI response" }] } }],
+				usageMetadata: { promptTokenCount: 500, totalTokenCount: 600 },
+			});
+
+			const log = makeLogger();
+			await new GeminiClient("test-api-key", [], log).ask("q", "s", "d");
+
+			expect(usageOf(log)).toMatchObject({ cachedTokens: 0, cachedRatio: 0 });
+		});
+
+		it("uses a null ratio rather than dividing by zero", async () => {
+			mockGenerateContent.mockResolvedValue({
+				candidates: [{ content: { parts: [{ text: "AI response" }] } }],
+				usageMetadata: { totalTokenCount: 0 },
+			});
+
+			const log = makeLogger();
+			await new GeminiClient("test-api-key", [], log).ask("q", "s", "d");
+
+			expect(usageOf(log)).toMatchObject({
+				promptTokens: 0,
+				cachedRatio: null,
+			});
+		});
+
+		it("warns instead of throwing when usage metadata is absent", async () => {
+			mockGenerateContent.mockResolvedValue({
+				candidates: [{ content: { parts: [{ text: "AI response" }] } }],
+			});
+
+			const log = makeLogger();
+			const result = await new GeminiClient("test-api-key", [], log).ask(
+				"q",
+				"s",
+				"d",
+			);
+
+			expect(result).toBe("AI response");
+			expect(usageOf(log)).toBeUndefined();
+			expect(log.warn).toHaveBeenCalledWith("Gemini usage metadata missing", {
+				mode: "generate",
+			});
+		});
+	});
+
 	describe("createGeminiClient", () => {
 		it("creates a new GeminiClient instance", () => {
 			const client = createGeminiClient("test-api-key");

--- a/src/clients/gemini.ts
+++ b/src/clients/gemini.ts
@@ -1,4 +1,8 @@
-import { type GenerateContentResponse, GoogleGenAI } from "@google/genai";
+import {
+	type GenerateContentResponse,
+	type GenerateContentResponseUsageMetadata,
+	GoogleGenAI,
+} from "@google/genai";
 import type { HistoryEntry } from "../types";
 import { getErrorMessage } from "../utils/errors";
 import { logger as defaultLogger, type Logger } from "../utils/logger";
@@ -93,6 +97,36 @@ ${historyText ? `会話履歴:\n${historyText}\n\n` : ""}質問: ${input}`;
 		throw new Error("AI処理中に予期しないエラーが発生しました。");
 	}
 
+	// トークン使用量を記録する。入力トークンがコストの大半を占めるため、
+	// 内訳とキャッシュのヒット率を追えるようにしておく。
+	private logUsage(
+		usage: GenerateContentResponseUsageMetadata | undefined,
+		mode: "generate" | "stream",
+	): void {
+		if (!usage) {
+			this.log.warn("Gemini usage metadata missing", { mode });
+			return;
+		}
+
+		const promptTokens = usage.promptTokenCount ?? 0;
+		const cachedTokens = usage.cachedContentTokenCount ?? 0;
+
+		this.log.info("Gemini token usage", {
+			mode,
+			model: GeminiClient.MODEL_NAME,
+			promptTokens,
+			cachedTokens,
+			// 暗黙キャッシュが効いているかはこの比率で判断する
+			cachedRatio:
+				promptTokens > 0
+					? Number((cachedTokens / promptTokens).toFixed(3))
+					: null,
+			thoughtsTokens: usage.thoughtsTokenCount ?? 0,
+			candidatesTokens: usage.candidatesTokenCount ?? 0,
+			totalTokens: usage.totalTokenCount ?? 0,
+		});
+	}
+
 	private addToHistory(input: string, response: string): void {
 		this.history.push({
 			role: "user",
@@ -132,6 +166,7 @@ ${historyText ? `会話履歴:\n${historyText}\n\n` : ""}質問: ${input}`;
 				this.log.info("Gemini API completed", {
 					durationMs: Date.now() - startTime,
 				});
+				this.logUsage(result.usageMetadata, "generate");
 			} catch (error) {
 				this.handleGeminiError(error);
 			}
@@ -178,6 +213,7 @@ ${historyText ? `会話履歴:\n${historyText}\n\n` : ""}質問: ${input}`;
 			const fullPrompt = this.buildPrompt(input, sheet, description);
 
 			let fullText = "";
+			let usage: GenerateContentResponseUsageMetadata | undefined;
 
 			try {
 				this.log.info("Gemini streaming API request starting");
@@ -197,6 +233,11 @@ ${historyText ? `会話履歴:\n${historyText}\n\n` : ""}質問: ${input}`;
 				);
 
 				for await (const chunk of stream) {
+					// ストリーミングでは使用量は終盤のチャンクに載るため、最後の値を採用する
+					if (chunk.usageMetadata) {
+						usage = chunk.usageMetadata;
+					}
+
 					const parts = chunk.candidates?.[0]?.content?.parts ?? [];
 					for (const part of parts) {
 						if (typeof part.text !== "string") {
@@ -214,6 +255,7 @@ ${historyText ? `会話履歴:\n${historyText}\n\n` : ""}質問: ${input}`;
 				this.log.info("Gemini streaming API completed", {
 					durationMs: Date.now() - startTime,
 				});
+				this.logUsage(usage, "stream");
 			} catch (error) {
 				this.handleGeminiError(error);
 			}


### PR DESCRIPTION
## 背景

Gemini APIのコストを調べたところ、シートCSVが毎リクエスト丸ごと渡っており、**入力トークンが全体の約95%**を占めていることが分かりました。

ところが `usageMetadata` はコード内のどこからも参照されておらず、実際の消費量が計測できない状態でした。現状の見積もり（1質問あたり約145,000トークン）はシートの実データからの推定値で、本番の実測値ではありません。

また Gemini 2.5以降は**暗黙キャッシュがデフォルトON**です。現在のプロンプトは静的なシートCSVが先頭に来ているため条件を満たしている可能性がありますが、実際に効いているかを確認する手段がありませんでした。

## 変更内容

`ask` / `askStream` の両方でトークン使用量を記録します。

```json
{
  "level": "INFO",
  "message": "Gemini token usage",
  "context": {
    "mode": "stream",
    "model": "gemini-3-flash-preview",
    "promptTokens": 110000,
    "cachedTokens": 88000,
    "cachedRatio": 0.8,
    "thoughtsTokens": 800,
    "candidatesTokens": 400,
    "totalTokens": 111200
  }
}
```

`cachedRatio` は `cachedContentTokenCount / promptTokenCount` です。**この値が0のままなら暗黙キャッシュが効いていない**と判断でき、明示キャッシュを入れるべきかの材料になります。

実装上の注意点:

- ストリーミングでは使用量が終盤のチャンクに載るため、最後に観測した値を採用しています
- `usageMetadata` が欠けていても回答を妨げないよう、警告のみ出して処理を続けます
- `promptTokenCount` が0のときは0除算を避けて `cachedRatio: null` にしています

## これで判断できるようになること

1. **実際の入力トークン数** — 推定値（約145,000）の答え合わせ
2. **暗黙キャッシュのヒット率** — 効いていればコード変更なしで割引済み
3. **明示キャッシュの損益分岐** — ストレージ代 $0.1456/時 に対し、質問頻度が約2.2件/時を超えるかどうか

## 確認事項

- [x] `npm run check`
- [x] `npm test`（178件通過、うち本PRで5件追加）

ログを増やすだけで挙動は変えていません。

## 関連

シートCSV自体を24.5%圧縮する #347 と独立して適用できます。両方入れると、圧縮後の実トークン数がこのログで確認できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)