### PR TITLE
chore: メインモデルを gemini-3.6-flash に切り替え

### DIFF
--- a/src/clients/gemini.ts
+++ b/src/clients/gemini.ts
@@ -9,7 +9,7 @@ import { logger as defaultLogger, type Logger } from "../utils/logger";
 import { withRetry } from "../utils/retry";
 
 export class GeminiClient {
-	private static readonly MODEL_NAME = "gemini-3-flash-preview";
+	private static readonly MODEL_NAME = "gemini-3.6-flash";
 
 	private client: GoogleGenAI;
 	private history: HistoryEntry[];


### PR DESCRIPTION
## 背景

`gemini-3-flash-preview` は **2025-12-17 に廃止が告知済み**で、Googleの推奨移行先が `gemini-3.6-flash`。シャットダウン日は未定（Computer Use をサポートする唯一のモデルであることが理由とされる）だが、告知済みのモデルを使い続ける運用リスクを避ける。

`gemini-3.6-flash` は 2026-07-21 にGA。廃止告知なし。

## トレードオフ

| | 3-flash-preview（変更前） | 3.6-flash（変更後） |
|---|---:|---:|
| AA Intelligence Index | 27 | **50** |
| 出力速度 (tok/s) | 167.7 | 231.4 |
| Time to First Token | 0.87秒 | **18.59秒** |
| 入力 $/M | 0.50 | 1.50 |
| 出力 $/M | 3.00 | 7.50 |
| キャッシュ読取 $/M | 0.05 | 0.15 |

**知能は1.85倍になるが、レイテンシは悪化する見込み。** 実測の出力1,616トークン（thinking 1,403 + 応答 213）を当てはめた推定:

- 変更前: 9.6秒 + TTFT 0.87秒 = 約 10.5秒（実測9.6〜13.9秒と整合）
- 変更後: 5.8秒 + TTFT 18.59秒 = 約 **24.4秒**

**コストは月 $0.78 → 約 $2.15。** 質問数が少ない（過去7日で11件）ため実質誤差。

## 注意点

**暗黙キャッシュはモデル単位なので、切り替え直後は `cachedRatio` が一時的に下がります。** 現在0.979で入力コストの84%を吸収しているため、最初の数件だけ数値が悪化して見えますが、性能劣化ではありません。

## デプロイ後に確認したいこと

- [ ] `durationMs` — 推定24.4秒まで悪化するか。体感として許容できるか
- [ ] `thoughtsTokens` — 公称「出力17%削減」が実際に効くか
- [ ] `cachedRatio` — 数件流したあと0.9以上に戻るか
- [ ] 回答品質の目視確認（Index 27→50 がこのRAGタスクに効くかは未知数）

**許容できない遅さなら revert してください。** 1行の変更です。

## 補足

AA Intelligence Index は GDPval / Terminal-Bench / SciCode / GPQA Diamond などで構成されており、**このBotのタスク（日本語でスプレッドシートを引くRAG）をほぼ測っていません。** 知能の向上が実際の回答品質に効くかは、実際の質問で確認する必要があります。

## 確認事項

- [x] `npm run check`
- [x] `npm test`（188件通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)