### PR TITLE
chore(deps): remove unused @cloudflare/workers-types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
 			"devDependencies": {
 				"@biomejs/biome": "2.5.5",
 				"@cloudflare/vitest-pool-workers": "^0.12.0",
-				"@cloudflare/workers-types": "^4.20240512.0",
 				"dotenv": "^17.0.0",
 				"typescript": "^7.0.0",
 				"vitest": "^3.0.0",
@@ -94,9 +93,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -114,9 +110,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -134,9 +127,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -154,9 +144,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -469,13 +456,6 @@
 			"engines": {
 				"node": ">=16"
 			}
-		},
-		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20260702.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
-			"integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0"
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
@@ -2418,6 +2398,7 @@
 			"integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/utils": "3.2.4",
 				"pathe": "^2.0.3",
@@ -2433,6 +2414,7 @@
 			"integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/pretty-format": "3.2.4",
 				"magic-string": "^0.30.17",
@@ -3523,6 +3505,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -4042,6 +4025,7 @@
 			"integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"pathe": "^2.0.3"
 			}
@@ -4052,6 +4036,7 @@
 			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -4150,6 +4135,7 @@
 			"integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/chai": "^5.2.2",
 				"@vitest/expect": "3.2.4",
@@ -4265,6 +4251,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"workerd": "bin/workerd"
 			},

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.5.5",
 		"@cloudflare/vitest-pool-workers": "^0.12.0",
-		"@cloudflare/workers-types": "^4.20240512.0",
 		"dotenv": "^17.0.0",
 		"typescript": "^7.0.0",
 		"vitest": "^3.0.0",


### PR DESCRIPTION
## 概要

未使用の devDependency `@cloudflare/workers-types` を削除します。

## 背景

Renovate の #331（workers-types v5 への更新）が CI 全滅で放置されていたため調査したところ、以下が判明しました。

### 1. この依存はどこからも使われていない

- [tsconfig.json](tsconfig.json) の `types` は `./worker-configuration.d.ts` のみを指定
- `src/` からの import なし
- リポジトリ全体の grep（node_modules / package-lock.json 除く）で、`package.json` 以外にヒットなし
- `scripts/`、`.github/workflows/`、`vitest.config.ts` いずれからも未参照

`wrangler types` はスタンドアロンの workers-types パッケージではなく、**workerd から直接ランタイム型を生成**しています（生成物ヘッダ: `Runtime types generated with workerd@1.20260310.1`）。

### 2. #331 はそもそもマージ不可能だった

wrangler 4.72.0 が `peerOptional @cloudflare/workers-types@"^4.20260310.1"` を宣言しているため、v5 に上げると CI の `npm ci` が ERESOLVE で失敗します（`npm install` は警告で通るため気付きにくい）。Renovate の `renovate/artifacts` が失敗し続けていたのも同じ原因です。

wrangler が v5 になるまで #331 は永久に赤のままなので、未使用の依存ごと削除するのが妥当と判断しました。

## 検証

`node_modules` から workers-types が消えた状態で、CI の全ジョブ相当をローカル実行:

| チェック | 結果 |
|---|---|
| `npm ci`（strict） | ✅ |
| `npx vitest run` | ✅ 14 files / 188 tests passed |
| `npm run cf-typegen` → `git diff --exit-code` | ✅ 差分なし |
| `npx biome check .` | ✅ エラーなし |
| `npx wrangler deploy --dry-run --minify src/index.ts` | ✅ |

加えて、`worker-configuration.d.ts` を**削除してゼロから再生成**しても、コミット済みファイルと完全一致（11,280行、差分ゼロ）することを確認しました。

## 影響

- 差分は `package.json` 1行削除と lockfile のみ
- `worker-configuration.d.ts` は無変更

## 関連

このPRがマージされたら #331 はクローズ予定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)