### PR TITLE
ci: bump Claude Code Action model to claude-opus-5

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,5 +35,5 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          claude_args: "--model claude-opus-4-6"
+          claude_args: "--model claude-opus-5"
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,5 +38,5 @@ jobs:
           github_token: ${{ secrets.PAT_TOKEN }}
           additional_permissions: |
             actions: read
-          claude_args: '--model claude-opus-4-6 --max-turns 50 --allowedTools "Read,Glob,Grep,Write,Edit,Bash(gh issue:*),Bash(gh search:*),Bash(gh pr:*),Bash(gh label:*),Bash(git:*),Bash(npm run check),Bash(npm test),Bash(npm run cf-typegen)"'
+          claude_args: '--model claude-opus-5 --max-turns 50 --allowedTools "Read,Glob,Grep,Write,Edit,Bash(gh issue:*),Bash(gh search:*),Bash(gh pr:*),Bash(gh label:*),Bash(git:*),Bash(npm run check),Bash(npm test),Bash(npm run cf-typegen)"'
 

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.PAT_TOKEN }}
-          claude_args: '--model claude-opus-4-6 --max-turns 30 --allowedTools "Read,Glob,Grep,Write,Edit,Bash(git:*),Bash(gh pr:*)"'
+          claude_args: '--model claude-opus-5 --max-turns 30 --allowedTools "Read,Glob,Grep,Write,Edit,Bash(git:*),Bash(gh pr:*)"'
           prompt: |
             You are a documentation sync assistant. A PR has just been merged, and you need to verify that CLAUDE.md is still accurate and up-to-date.
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.PAT_TOKEN }}
-          claude_args: '--model claude-opus-4-6 --max-turns 30 --allowedTools "Read,Glob,Grep,Write,Edit,Bash(gh issue:*),Bash(gh search:*),Bash(gh pr:*),Bash(gh label:*),Bash(git:*),Bash(npm run check),Bash(npm test)"'
+          claude_args: '--model claude-opus-5 --max-turns 30 --allowedTools "Read,Glob,Grep,Write,Edit,Bash(gh issue:*),Bash(gh search:*),Bash(gh pr:*),Bash(gh label:*),Bash(git:*),Bash(npm run check),Bash(npm test)"'
           prompt: |
             You are an AI issue triage assistant for this repository. Analyze the newly opened issue and perform a comprehensive triage.
 

--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.PAT_TOKEN }}
-          claude_args: '--model claude-opus-4-6 --max-turns 30 --allowedTools "Read,Glob,Grep,Write,Edit,Bash(git:*),Bash(gh pr:*)"'
+          claude_args: '--model claude-opus-5 --max-turns 30 --allowedTools "Read,Glob,Grep,Write,Edit,Bash(git:*),Bash(gh pr:*)"'
           prompt: |
             You are a documentation reviewer for README.md. **Your default outcome is to do nothing.**
 

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -32,7 +32,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           max_turns: "20"
-          claude_args: '--model claude-opus-4-6 --allowedTools "Read,Glob,Grep,Bash(git diff:*),Bash(git log:*),Bash(git show:*)"'
+          claude_args: '--model claude-opus-5 --allowedTools "Read,Glob,Grep,Bash(git diff:*),Bash(git log:*),Bash(git show:*)"'
           direct_prompt: |
             You are a security-focused code reviewer. Analyze the changes in this PR from a security perspective only.
 


### PR DESCRIPTION
## 概要

`claude-code-action` を使う6ワークフローが `claude-opus-4-6` を指定したままだったので、現行の最新 Opus である `claude-opus-5` に更新します。

| ワークフロー | 用途 |
|---|---|
| `claude.yml` | `@claude` メンションでの対話 |
| `claude-code-review.yml` | PRの自動コードレビュー |
| `security-review.yml` | PRのセキュリティレビュー |
| `issue-triage.yml` | Issue の自動トリアージ |
| `docs-sync.yml` | CLAUDE.md の同期 |
| `readme-sync.yml` | README.md の同期（#354 で変更駆動化） |

## 変更内容

`--model` フラグの値を差し替えただけです。`--max-turns`、`--allowedTools`、プロンプトはいずれも変更していません。

```diff
-claude_args: '--model claude-opus-4-6 --max-turns 30 --allowedTools "..."'
+claude_args: '--model claude-opus-5 --max-turns 30 --allowedTools "..."'
```

## 料金

**Opus 4.6 と同額**です（入力 $5 / 出力 $25 per MTok）。値上がりはありません。

## 検証

- 6ファイルすべてで `claude-opus-4-6` が残っていないことを確認
- `.github/workflows/` の全YAMLをパースして構文エラーがないことを確認
- **`security-review.yml` は全PRで実行されるため、本PR自体が新しいモデルIDの実地テストになります。** このPRで security-review がグリーンになれば、`claude-code-action` が `claude-opus-5` を受け付けることが実証されます

## 補足

Opus 4.6 → Opus 5 は API レベルではいくつか破壊的変更（`temperature` などのサンプリングパラメータ廃止、`thinking` のデフォルト変更）がありますが、**本リポジトリは `claude-code-action` 経由でモデルIDを渡しているだけ**で、API を直接叩いてはいません。これらのパラメータはどのワークフローでも指定していないため影響しません。

なお本リポジトリの Bot 本体が使う Gemini とは無関係です（`src/clients/gemini.ts`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)