### PR TITLE
ci: add typecheck and verify quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           node-version: '24'
           cache: 'npm'
       - run: npm ci
+      - run: npm run typecheck
       - run: npm run cf-typegen
       - name: Check generated types are committed
         run: git diff --exit-code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,8 @@ npm test             # Run tests with Vitest
 npm run register     # Register Discord slash commands via Discord API
 npm run check        # Run Biome formatter + linter with auto-fix
 npm run check:ci     # Run Biome check without writing (for CI)
+npm run typecheck    # Run TypeScript type checking without emitting files
+npm run verify       # Run all non-writing checks, tests, and a deploy dry-run
 ```
 
 ## Architecture

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
 		"lint": "biome lint .",
 		"format": "biome format --write .",
 		"check": "biome check --write .",
-		"check:ci": "biome check ."
+		"check:ci": "biome check .",
+		"typecheck": "tsc --noEmit",
+		"verify": "npm run check:ci && npm run typecheck && npm test && wrangler deploy --dry-run --minify src/index.ts"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.5",

--- a/src/clients/gemini.test.ts
+++ b/src/clients/gemini.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HistoryEntry } from "../types";
+import type { Logger } from "../utils/logger";
 
 const mockGenerateContent = vi.fn();
 const mockGenerateContentStream = vi.fn();
@@ -30,7 +32,9 @@ describe("GeminiClient", () => {
 		});
 
 		it("initializes with provided history", () => {
-			const history = [{ role: "user", text: "previous question" }];
+			const history: HistoryEntry[] = [
+				{ role: "user", text: "previous question" },
+			];
 			const client = new GeminiClient("test-api-key", history);
 			expect(client.getHistory()).toEqual(history);
 		});
@@ -129,7 +133,7 @@ describe("GeminiClient", () => {
 				],
 			});
 
-			const history = [{ role: "user", text: "previous" }];
+			const history: HistoryEntry[] = [{ role: "user", text: "previous" }];
 			const client = new GeminiClient("test-api-key", history);
 
 			await client.ask("new question", "sheet", "desc");
@@ -320,7 +324,7 @@ describe("GeminiClient", () => {
 			})();
 			mockGenerateContentStream.mockResolvedValue(mockStream);
 
-			const history = [{ role: "user", text: "previous" }];
+			const history: HistoryEntry[] = [{ role: "user", text: "previous" }];
 			const client = new GeminiClient("test-api-key", history);
 
 			await client.askStream("new question", "sheet", "desc", async () => {});
@@ -353,7 +357,7 @@ describe("GeminiClient", () => {
 				// Pass null in history to cause a TypeError in buildPrompt's map()
 				// TypeError message doesn't contain "API" or "AI"
 				const client = new GeminiClient("test-api-key", [
-					null as unknown as { role: string; text: string },
+					null as unknown as HistoryEntry,
 				]);
 
 				await expect(client.ask("q", "s", "d")).rejects.toThrow(
@@ -381,7 +385,7 @@ describe("GeminiClient", () => {
 				// Pass null in history to cause a TypeError in buildPrompt's map()
 				// TypeError message doesn't contain "API" or "AI"
 				const client = new GeminiClient("test-api-key", [
-					null as unknown as { role: string; text: string },
+					null as unknown as HistoryEntry,
 				]);
 
 				await expect(
@@ -418,7 +422,11 @@ describe("GeminiClient", () => {
 			});
 
 			const log = makeLogger();
-			await new GeminiClient("test-api-key", [], log).ask("q", "s", "d");
+			await new GeminiClient("test-api-key", [], log as unknown as Logger).ask(
+				"q",
+				"s",
+				"d",
+			);
 
 			expect(usageOf(log)).toMatchObject({
 				mode: "generate",
@@ -446,12 +454,11 @@ describe("GeminiClient", () => {
 			mockGenerateContentStream.mockResolvedValue(mockStream);
 
 			const log = makeLogger();
-			await new GeminiClient("test-api-key", [], log).askStream(
-				"q",
-				"s",
-				"d",
-				async () => {},
-			);
+			await new GeminiClient(
+				"test-api-key",
+				[],
+				log as unknown as Logger,
+			).askStream("q", "s", "d", async () => {});
 
 			expect(usageOf(log)).toMatchObject({
 				mode: "stream",
@@ -468,7 +475,11 @@ describe("GeminiClient", () => {
 			});
 
 			const log = makeLogger();
-			await new GeminiClient("test-api-key", [], log).ask("q", "s", "d");
+			await new GeminiClient("test-api-key", [], log as unknown as Logger).ask(
+				"q",
+				"s",
+				"d",
+			);
 
 			expect(usageOf(log)).toMatchObject({ cachedTokens: 0, cachedRatio: 0 });
 		});
@@ -480,7 +491,11 @@ describe("GeminiClient", () => {
 			});
 
 			const log = makeLogger();
-			await new GeminiClient("test-api-key", [], log).ask("q", "s", "d");
+			await new GeminiClient("test-api-key", [], log as unknown as Logger).ask(
+				"q",
+				"s",
+				"d",
+			);
 
 			expect(usageOf(log)).toMatchObject({
 				promptTokens: 0,
@@ -494,11 +509,11 @@ describe("GeminiClient", () => {
 			});
 
 			const log = makeLogger();
-			const result = await new GeminiClient("test-api-key", [], log).ask(
-				"q",
-				"s",
-				"d",
-			);
+			const result = await new GeminiClient(
+				"test-api-key",
+				[],
+				log as unknown as Logger,
+			).ask("q", "s", "d");
 
 			expect(result).toBe("AI response");
 			expect(usageOf(log)).toBeUndefined();
@@ -515,7 +530,7 @@ describe("GeminiClient", () => {
 		});
 
 		it("creates client with initial history", () => {
-			const history = [{ role: "user", text: "hello" }];
+			const history: HistoryEntry[] = [{ role: "user", text: "hello" }];
 			const client = createGeminiClient("test-api-key", history);
 			expect(client.getHistory()).toEqual(history);
 		});

--- a/src/clients/kv.test.ts
+++ b/src/clients/kv.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import type { HistoryEntry } from "../types";
 import { createKV, KV } from "./kv";
 
 const createMockKVNamespace = () =>
@@ -22,7 +23,7 @@ describe("KV class", () => {
 
 	describe("saveHistory", () => {
 		it("saves history with expirationTtl", async () => {
-			const history = [{ role: "user", text: "hello" }];
+			const history: HistoryEntry[] = [{ role: "user", text: "hello" }];
 
 			await kv.saveHistory(history);
 

--- a/src/clients/spreadSheet.test.ts
+++ b/src/clients/spreadSheet.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Logger } from "../utils/logger";
 
 const mockGetGoogleAuthToken = vi.fn();
 const mockLoadInfo = vi.fn();
@@ -40,7 +41,7 @@ const mockLogger = {
 	error: vi.fn(),
 	debug: vi.fn(),
 	withContext: vi.fn().mockReturnThis(),
-};
+} as unknown as Logger;
 
 function setupSheets(options?: {
 	hasTestSheet?: boolean;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -43,6 +43,14 @@ const mockExecutionCtx = {
 	passThroughOnException: () => {},
 } as unknown as ExecutionContext;
 
+type ErrorResponseBody = {
+	data: {
+		embeds: Array<{
+			description?: string;
+		}>;
+	};
+};
+
 function postRequest(body: unknown) {
 	return new Request("http://localhost/", {
 		method: "POST",
@@ -118,7 +126,7 @@ describe("index", () => {
 			);
 
 			expect(res.status).toBe(200);
-			const json = await res.json();
+			const json = (await res.json()) as ErrorResponseBody;
 			expect(json.data.embeds[0].description).toBe(
 				"Invalid Discord interaction: missing data",
 			);
@@ -132,7 +140,7 @@ describe("index", () => {
 			);
 
 			expect(res.status).toBe(200);
-			const json = await res.json();
+			const json = (await res.json()) as ErrorResponseBody;
 			expect(json.data.embeds[0].description).toBe(
 				"Invalid Discord interaction: missing options",
 			);
@@ -150,7 +158,7 @@ describe("index", () => {
 			);
 
 			expect(res.status).toBe(200);
-			const json = await res.json();
+			const json = (await res.json()) as ErrorResponseBody;
 			expect(json.data.embeds[0].description).toBe(
 				"Invalid Discord interaction: question must be a non-empty string",
 			);
@@ -170,7 +178,7 @@ describe("index", () => {
 			);
 
 			expect(res.status).toBe(200);
-			const json = await res.json();
+			const json = (await res.json()) as ErrorResponseBody;
 			expect(json.data.embeds[0].description).toBe(
 				"Failed to start processing",
 			);
@@ -186,7 +194,7 @@ describe("index", () => {
 			);
 
 			expect(res.status).toBe(200);
-			const json = await res.json();
+			const json = (await res.json()) as ErrorResponseBody;
 			expect(json.data.embeds[0].description).toBe("Invalid interaction type");
 		});
 	});

--- a/src/workflows/answerQuestionWorkflow.test.ts
+++ b/src/workflows/answerQuestionWorkflow.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Bindings } from "../types";
+import type { Bindings, HistoryEntry } from "../types";
 import type { Logger } from "../utils/logger";
 import type { HistoryOutput, SheetDataOutput } from "./types";
 
@@ -89,9 +89,11 @@ const mockAnalyticsDataset = {
 	writeDataPoint: vi.fn(),
 };
 
+const mockKVGet = vi.fn<() => Promise<string | null>>();
+const mockKVPut = vi.fn();
 const mockKVNamespace = {
-	get: vi.fn(),
-	put: vi.fn(),
+	get: mockKVGet,
+	put: mockKVPut,
 } as unknown as KVNamespace;
 
 const mockEnv: Bindings = {
@@ -202,7 +204,7 @@ describe("AnswerQuestionWorkflow Steps", () => {
 
 	describe("saveHistoryStep", () => {
 		it("saves history to KV", async () => {
-			const updatedHistory = [
+			const updatedHistory: HistoryEntry[] = [
 				{ role: "user", text: "question" },
 				{ role: "model", text: "answer" },
 			];
@@ -231,7 +233,7 @@ describe("AnswerQuestionWorkflow Steps", () => {
 		const history: HistoryOutput = { history: [] };
 
 		it("streams Gemini response and edits Discord message", async () => {
-			const updatedHistory = [
+			const updatedHistory: HistoryEntry[] = [
 				{ role: "user", text: "質問: test message" },
 				{ role: "model", text: "full response" },
 			];
@@ -420,7 +422,9 @@ describe("AnswerQuestionWorkflow Steps", () => {
 		});
 
 		it("passes existing history to GeminiClient", async () => {
-			const existingHistory = [{ role: "user", text: "previous" }];
+			const existingHistory: HistoryEntry[] = [
+				{ role: "user", text: "previous" },
+			];
 			const historyWithExisting: HistoryOutput = {
 				history: existingHistory,
 			};
@@ -514,7 +518,7 @@ describe("AnswerQuestionWorkflow Steps", () => {
 
 		it("skips when KV cache indicates already reported", async () => {
 			mockGitHubInstance.generateFingerprint.mockReturnValue("fingerprint-1");
-			vi.mocked(mockKVNamespace.get).mockResolvedValue("1");
+			mockKVGet.mockResolvedValue("1");
 
 			await reportErrorToGitHub(mockEnv, sampleReport, mockLogger);
 
@@ -524,7 +528,7 @@ describe("AnswerQuestionWorkflow Steps", () => {
 
 		it("skips when GitHub search finds duplicate", async () => {
 			mockGitHubInstance.generateFingerprint.mockReturnValue("fingerprint-2");
-			vi.mocked(mockKVNamespace.get).mockResolvedValue(null);
+			mockKVGet.mockResolvedValue(null);
 			mockGitHubInstance.isDuplicate.mockResolvedValue(true);
 
 			await reportErrorToGitHub(mockEnv, sampleReport, mockLogger);
@@ -540,7 +544,7 @@ describe("AnswerQuestionWorkflow Steps", () => {
 
 		it("creates issue and caches in KV on new error", async () => {
 			mockGitHubInstance.generateFingerprint.mockReturnValue("fingerprint-3");
-			vi.mocked(mockKVNamespace.get).mockResolvedValue(null);
+			mockKVGet.mockResolvedValue(null);
 			mockGitHubInstance.isDuplicate.mockResolvedValue(false);
 			mockGitHubInstance.createIssue.mockResolvedValue(true);
 


### PR DESCRIPTION
Fixes #359

## Summary

- add `npm run typecheck` using `tsc --noEmit`
- add `npm run verify` to run Biome, type checking, tests, and a Wrangler deploy dry-run
- run the actual TypeScript compiler in CI's typecheck job
- make existing tests type-correct so test files remain inside the TypeScript quality gate
- document the new commands in `CLAUDE.md`

## Why

The existing CI job named `typecheck` only regenerated Cloudflare binding types and checked the generated diff. It did not invoke the TypeScript compiler, so type errors in application and test code could reach main undetected.

Enabling `tsc --noEmit` exposed type-inference issues in existing tests. Those tests now use explicit domain types and typed/cast test doubles without changing runtime behavior.

## Developer impact

Developers can run the same non-writing validation sequence locally with:

```bash
npm run verify
```

No Discord, Worker, Workflow, KV, or environment-variable contract changes are included.

## Validation

- `npm run verify`
- 14 test files passed
- 188 tests passed
- Wrangler deploy dry-run succeeded

Biome reports existing optional-chain suggestions and a configuration deprecation notice as non-failing warnings; this PR does not expand its scope to unrelated production-code cleanup.

## Compatibility and rollback

The change only adds development scripts, CI validation, documentation, and type-only test corrections. It can be reverted as a single commit without data or deployment migration.
