### PR TITLE
docs: sync CLAUDE.md after PR #372

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,61 @@ npm run check        # Run Biome formatter + linter with auto-fix
 npm run check:ci     # Run Biome check without writing (for CI)
 npm run typecheck    # Run TypeScript type checking without emitting files
 npm run verify       # Run all non-writing checks, tests, and a deploy dry-run
+npm run test:watch   # Run tests in watch mode
+npm run lint         # Run Biome linter only
+npm run format       # Run Biome formatter with auto-fix
+npm run cf-typegen   # Regenerate worker-configuration.d.ts from wrangler.toml
 ```
 
 ## Architecture
 
-Discord bot on Cloudflare Workers. Uses Google Gemini AI with a Google Sheets knowledge base. Cron health check (every 5 min) reports failures as GitHub Issues.
+Discord bot on Cloudflare Workers (Hono). Uses Google Gemini AI with a Google Sheets knowledge base. Cron health check (every 5 min) reports failures as GitHub Issues.
+
+### Request Flow
+
+1. Discord posts an interaction to `POST /`; the `verifyDiscordInteraction` middleware verifies the Ed25519 signature.
+2. `InteractionType.PING` is answered with `PONG` immediately. `APPLICATION_COMMAND` calls `loadConfig(c.env)` to fail fast on misconfiguration, validates the payload, creates an `ANSWER_QUESTION_WORKFLOW` instance, and returns `DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE`.
+3. `AnswerQuestionWorkflow` runs the steps `getSheetData` → `getHistory` → `streamGeminiAndEditDiscord` (2 retries, 120s timeout) → `saveHistory`.
+4. The streaming step progressively edits the original Discord message. Edits are throttled per phase (thinking: 1000ms / 200 chars, response: 1500ms / 50 chars), and thinking text is summarized with `GEMINI_SUMMARY_MODEL`.
+5. On failure the workflow records metrics, reports to GitHub Issues (non-fatal, outside `step.do`), and posts an error message via `sendErrorResponse` (up to 3 attempts, exponential backoff).
+
+The cron trigger (`*/5 * * * *`) invokes `scheduled`, which runs `runHealthCheck`: KV, the Gemini API, and the Google Service Account JSON are checked in parallel, and a GitHub Issue is filed when any check fails.
+
+### Caching
+
+All entries live in the KV namespace bound as `sushanshan_bot` and expire via KV native TTL:
+
+- `sheet_info` - Google Sheets snapshot, fixed 5 minute TTL (`SHEET_CACHE_TTL_SECONDS` in `src/clients/kv.ts`). Cache writes are best effort and never fail the workflow.
+- `chat_history` - conversation history, TTL from `HISTORY_TTL_SECONDS` (default 300 seconds).
+- `error_reported:<fingerprint>` - 1 hour TTL. First-layer deduplication for error and health-check reports; a GitHub Issues search is the second layer.
+
+## Project Structure
+
+```
+src/
+  index.ts          # Hono app, Discord interaction handler, scheduled (cron) entrypoint
+  config.ts         # loadConfig / DEFAULT_RUNTIME_CONFIG / ConfigError - env validation
+  contracts.ts      # Dependency-free shared types (Bindings, WorkflowParams, HistoryEntry, ...)
+  health.ts         # Cron health check and GitHub Issue reporting
+  clients/
+    discord.ts      # Discord webhook client (edit/post the original message)
+    gemini.ts       # Gemini client (streaming answers, history)
+    github.ts       # GitHub Issue client (error/health reports, dedup fingerprints)
+    kv.ts           # KV access (sheet cache, conversation history)
+    metrics.ts      # Analytics Engine metrics client and NoOp fallback
+    spreadSheet.ts  # Google Sheets fetch via service account
+  middleware/
+    verifyDiscordInteraction.ts  # Ed25519 signature verification
+  responses/
+    errorResponse.ts             # Discord error message payload
+  utils/            # compactSheet, errors, logger, requestId, retry
+  workflows/
+    answerQuestionWorkflow.ts    # AnswerQuestionWorkflow and its steps
+    types.ts                     # Step output types
+scripts/            # register.js (slash command registration), commands.js (definitions)
+```
+
+Tests live next to their subject as `*.test.ts`.
 
 ## Environment Variables
 
@@ -34,6 +84,17 @@ Optional runtime configuration (current production values are used when omitted)
 - `GOOGLE_SPREADSHEET_ID`, `GOOGLE_DATA_SHEET_NAME`, `GOOGLE_DESCRIPTION_SHEET_NAME` - Google Sheets source
 - `GITHUB_REPOSITORY` - Error-report destination in `owner/repository` format
 - `HISTORY_TTL_SECONDS` - Conversation history TTL (60–86400 seconds, default: 300)
+
+Defaults for the optional values live in `DEFAULT_RUNTIME_CONFIG` (`src/config.ts`); `loadConfig` validates every value and throws `ConfigError` on invalid input.
+
+## Cloudflare Bindings
+
+Defined in `wrangler.toml` and typed in `Bindings` (`src/contracts.ts`):
+
+- `sushanshan_bot` - KV namespace for the sheet cache, conversation history, and error-report deduplication
+- `ANSWER_QUESTION_WORKFLOW` - Workflow binding for the `AnswerQuestionWorkflow` class (`answer-question-workflow`)
+- `METRICS` (optional) - Analytics Engine dataset `yangbingyibot_metrics`; falls back to `NoOpMetricsClient` when unbound
+- `[triggers] crons = ["*/5 * * * *"]` - health check schedule
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary

CLAUDE.md の内容を PR #372 (refactor: 実行時設定とドメイン契約を集約する) のマージ後の実コードと同期します。

PR #372 で追加された任意の環境変数はすでに CLAUDE.md へ反映済みでしたが、検証の過程で以下の既存の記載漏れ・不正確な点が見つかったため、あわせて修正します。

## Changes

- **Architecture**: 1行の概要のみだったため、実装に沿ってリクエストフローを追記（署名検証 → PING/PONG → `loadConfig` によるフェイルファスト → Deferred 応答 → Workflow の `getSheetData` → `getHistory` → `streamGeminiAndEditDiscord`（リトライ2回・120秒タイムアウト）→ `saveHistory`、失敗時の GitHub Issue 報告とエラー応答、cron による `runHealthCheck`）
- **Architecture**: キャッシュ戦略の記載を新設。KV `sushanshan_bot` の `sheet_info`（固定5分TTL）、`chat_history`（`HISTORY_TTL_SECONDS`、既定300秒）、`error_reported:<fingerprint>`（1時間TTL・重複報告の1段目）を明記
- **Project Structure**: セクション自体が存在しなかったため新設。PR #372 で追加された `src/config.ts` と `src/contracts.ts`（削除された `src/types.ts` の後継）を含む実際のファイル構成を記載
- **Cloudflare Bindings**: セクションを新設。wrangler.toml と `Bindings` 型に存在するが未記載だった `sushanshan_bot`（KV）、`ANSWER_QUESTION_WORKFLOW`（Workflow）、`METRICS`（Analytics Engine・任意、未バインド時は `NoOpMetricsClient`）、cron トリガーを追加
- **Environment Variables**: 任意設定の既定値が `DEFAULT_RUNTIME_CONFIG` (`src/config.ts`) にあり、`loadConfig` が検証して `ConfigError` を投げる点を補足
- **Development Commands**: package.json に存在するが未記載だった `test:watch`, `lint`, `format`, `cf-typegen` を追加

変更は CLAUDE.md のみです。

---
Auto-generated by docs-sync workflow.
