### PR TITLE
refactor: Discord Interactionを型安全に解析する

### DIFF
--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -12,6 +12,7 @@ const WEN_COMMAND = {
 			name: "question",
 			description: "The question you want to ask",
 			required: true,
+			max_length: 6000,
 		},
 	],
 };

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -3,24 +3,10 @@ export type HistoryEntry = {
 	text: string;
 };
 
-export type DiscordCommandOption = {
-	name?: string;
-	value?: unknown;
-};
-
-/**
- * Discord's untrusted request payload at the HTTP boundary.
- * Refactor 03 will validate and narrow every field before use.
- */
-export type DiscordInteractionPayload = {
-	type: number;
+export type ParsedDiscordAskCommand = {
 	token: string;
-	guild_id?: string;
-	channel_id?: string;
-	data?: {
-		name?: string;
-		options?: DiscordCommandOption[];
-	};
+	question: string;
+	conversationKey: string;
 };
 
 // Workflow event payload shared by the Worker boundary and Workflow entrypoint.
@@ -28,6 +14,7 @@ export interface WorkflowParams {
 	token: string;
 	message: string;
 	requestId: string;
+	conversationKey: string;
 }
 
 /**

--- a/src/discord/interaction.test.ts
+++ b/src/discord/interaction.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import {
+	createConversationKey,
+	getInteractionType,
+	parseDiscordAskCommand,
+} from "./interaction";
+
+function guildInteraction(question = "  質問です  ") {
+	return {
+		type: 2,
+		token: "interaction-token",
+		guild_id: "guild-1",
+		channel_id: "channel-1",
+		member: {
+			user: {
+				id: "user-1",
+			},
+		},
+		data: {
+			name: "ask",
+			options: [
+				{ name: "other", type: 3, value: "ignored" },
+				{ name: "question", type: 3, value: question },
+			],
+		},
+	};
+}
+
+function dmInteraction(question = "DM question") {
+	return {
+		type: 2,
+		token: "dm-token",
+		channel_id: "dm-channel",
+		user: {
+			id: "dm-user",
+		},
+		data: {
+			name: "ask",
+			options: [{ name: "question", type: 3, value: question }],
+		},
+	};
+}
+
+describe("Discord interaction parsing", () => {
+	it("reads the interaction type only from an object with a numeric type", () => {
+		expect(getInteractionType({ type: 1 })).toBe(1);
+		expect(getInteractionType({ type: "1" })).toBeUndefined();
+		expect(getInteractionType(null)).toBeUndefined();
+	});
+
+	it("parses a guild command by option name and hashes its conversation IDs", async () => {
+		const parsed = await parseDiscordAskCommand(guildInteraction());
+
+		expect(parsed).toEqual({
+			token: "interaction-token",
+			question: "質問です",
+			conversationKey: expect.stringMatching(/^[0-9a-f]{64}$/),
+		});
+		expect(JSON.stringify(parsed)).not.toContain("user-1");
+		expect(JSON.stringify(parsed)).not.toContain("channel-1");
+		expect(JSON.stringify(parsed)).not.toContain("guild-1");
+	});
+
+	it("parses a DM command using the top-level user", async () => {
+		const parsed = await parseDiscordAskCommand(dmInteraction());
+
+		expect(parsed.token).toBe("dm-token");
+		expect(parsed.question).toBe("DM question");
+		expect(parsed.conversationKey).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it.each([
+		["command name", { ...guildInteraction(), data: { name: "other" } }],
+		["token", { ...guildInteraction(), token: " " }],
+		["channel", { ...guildInteraction(), channel_id: undefined }],
+		["guild user", { ...guildInteraction(), member: undefined }],
+		["DM user", { ...dmInteraction(), user: undefined }],
+		[
+			"option name",
+			{
+				...guildInteraction(),
+				data: {
+					name: "ask",
+					options: [{ name: "other", type: 3, value: "question" }],
+				},
+			},
+		],
+		[
+			"option type",
+			{
+				...guildInteraction(),
+				data: {
+					name: "ask",
+					options: [{ name: "question", type: 4, value: "question" }],
+				},
+			},
+		],
+	])("rejects a missing or invalid %s", async (_label, interaction) => {
+		await expect(parseDiscordAskCommand(interaction)).rejects.toThrow(
+			"Invalid Discord interaction",
+		);
+	});
+
+	it("accepts a 6000-character trimmed question", async () => {
+		const parsed = await parseDiscordAskCommand(
+			guildInteraction("x".repeat(6000)),
+		);
+
+		expect(parsed.question).toHaveLength(6000);
+	});
+
+	it.each(["   ", "x".repeat(6001)])(
+		"rejects an empty or oversized question",
+		async (question) => {
+			await expect(
+				parseDiscordAskCommand(guildInteraction(question)),
+			).rejects.toThrow(
+				"Invalid Discord interaction: question must be between 1 and 6000 characters",
+			);
+		},
+	);
+});
+
+describe("conversation keys", () => {
+	it("is stable for the same guild, channel, and user", async () => {
+		const input = {
+			guildId: "guild-1",
+			channelId: "channel-1",
+			userId: "user-1",
+		};
+
+		expect(await createConversationKey(input)).toBe(
+			await createConversationKey(input),
+		);
+	});
+
+	it("changes when the user or channel changes", async () => {
+		const baseline = await createConversationKey({
+			guildId: "guild-1",
+			channelId: "channel-1",
+			userId: "user-1",
+		});
+		const otherUser = await createConversationKey({
+			guildId: "guild-1",
+			channelId: "channel-1",
+			userId: "user-2",
+		});
+		const otherChannel = await createConversationKey({
+			guildId: "guild-1",
+			channelId: "channel-2",
+			userId: "user-1",
+		});
+
+		expect(otherUser).not.toBe(baseline);
+		expect(otherChannel).not.toBe(baseline);
+	});
+
+	it("uses a distinct namespace for DM conversations", async () => {
+		const dm = await createConversationKey({
+			channelId: "channel-1",
+			userId: "user-1",
+		});
+		const guild = await createConversationKey({
+			guildId: "guild-1",
+			channelId: "channel-1",
+			userId: "user-1",
+		});
+
+		expect(dm).not.toBe(guild);
+		expect(dm).toMatch(/^[0-9a-f]{64}$/);
+	});
+});

--- a/src/discord/interaction.ts
+++ b/src/discord/interaction.ts
@@ -1,0 +1,149 @@
+import type { ParsedDiscordAskCommand } from "../contracts";
+
+const APPLICATION_COMMAND_INTERACTION_TYPE = 2;
+const STRING_COMMAND_OPTION_TYPE = 3;
+const ASK_COMMAND_NAME = "ask";
+const QUESTION_OPTION_NAME = "question";
+const MAX_QUESTION_LENGTH = 6000;
+const DM_GUILD_NAMESPACE = "dm";
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getNonEmptyString(
+	record: UnknownRecord,
+	key: string,
+	errorMessage: string,
+): string {
+	const value = record[key];
+	if (typeof value !== "string" || value.trim().length === 0) {
+		throw new Error(errorMessage);
+	}
+	return value.trim();
+}
+
+function getUserId(body: UnknownRecord, guildId: string | undefined): string {
+	if (guildId !== undefined) {
+		const member = body.member;
+		if (!isRecord(member) || !isRecord(member.user)) {
+			throw new Error("Invalid Discord interaction: missing or invalid user");
+		}
+		return getNonEmptyString(
+			member.user,
+			"id",
+			"Invalid Discord interaction: missing or invalid user",
+		);
+	}
+
+	const user = body.user;
+	if (!isRecord(user)) {
+		throw new Error("Invalid Discord interaction: missing or invalid user");
+	}
+	return getNonEmptyString(
+		user,
+		"id",
+		"Invalid Discord interaction: missing or invalid user",
+	);
+}
+
+function bytesToHex(bytes: ArrayBuffer): string {
+	return Array.from(new Uint8Array(bytes), (byte) =>
+		byte.toString(16).padStart(2, "0"),
+	).join("");
+}
+
+export function getInteractionType(value: unknown): number | undefined {
+	if (!isRecord(value) || typeof value.type !== "number") {
+		return undefined;
+	}
+	return value.type;
+}
+
+export async function createConversationKey({
+	guildId,
+	channelId,
+	userId,
+}: {
+	guildId?: string;
+	channelId: string;
+	userId: string;
+}): Promise<string> {
+	const material = `${guildId ?? DM_GUILD_NAMESPACE}:${channelId}:${userId}`;
+	const digest = await crypto.subtle.digest(
+		"SHA-256",
+		new TextEncoder().encode(material),
+	);
+	return bytesToHex(digest);
+}
+
+export async function parseDiscordAskCommand(
+	value: unknown,
+): Promise<ParsedDiscordAskCommand> {
+	if (!isRecord(value) || value.type !== APPLICATION_COMMAND_INTERACTION_TYPE) {
+		throw new Error("Invalid Discord interaction: invalid command type");
+	}
+
+	const token = getNonEmptyString(
+		value,
+		"token",
+		"Invalid Discord interaction: missing or invalid token",
+	);
+	const channelId = getNonEmptyString(
+		value,
+		"channel_id",
+		"Invalid Discord interaction: missing or invalid channel",
+	);
+
+	const rawGuildId = value.guild_id;
+	if (
+		rawGuildId !== undefined &&
+		(typeof rawGuildId !== "string" || rawGuildId.trim().length === 0)
+	) {
+		throw new Error("Invalid Discord interaction: invalid guild");
+	}
+	const guildId =
+		typeof rawGuildId === "string" ? rawGuildId.trim() : undefined;
+	const userId = getUserId(value, guildId);
+
+	const data = value.data;
+	if (!isRecord(data) || data.name !== ASK_COMMAND_NAME) {
+		throw new Error("Invalid Discord interaction: invalid command");
+	}
+	if (!Array.isArray(data.options)) {
+		throw new Error(
+			"Invalid Discord interaction: missing or invalid question option",
+		);
+	}
+
+	const questionOption = data.options.find(
+		(option) =>
+			isRecord(option) &&
+			option.name === QUESTION_OPTION_NAME &&
+			option.type === STRING_COMMAND_OPTION_TYPE,
+	);
+	if (!isRecord(questionOption) || typeof questionOption.value !== "string") {
+		throw new Error(
+			"Invalid Discord interaction: missing or invalid question option",
+		);
+	}
+
+	const question = questionOption.value.trim();
+	if (question.length === 0 || question.length > MAX_QUESTION_LENGTH) {
+		throw new Error(
+			`Invalid Discord interaction: question must be between 1 and ${MAX_QUESTION_LENGTH} characters`,
+		);
+	}
+
+	return {
+		token,
+		question,
+		conversationKey: await createConversationKey({
+			guildId,
+			channelId,
+			userId,
+		}),
+	};
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -17,12 +17,18 @@ vi.mock("./utils/requestId", () => ({
 }));
 
 vi.mock("discord-api-types/v10", () => ({
+	ApplicationCommandOptionType: {
+		String: 3,
+	},
+	InteractionType: {
+		ApplicationCommand: 2,
+	},
 	InteractionResponseType: {
 		ChannelMessageWithSource: 4,
 	},
 }));
 
-import type { Bindings } from "./contracts";
+import type { Bindings, WorkflowParams } from "./contracts";
 import { app } from "./index";
 
 const mockWorkflowCreate = vi.fn();
@@ -34,8 +40,9 @@ const mockEnv: Bindings = {
 	GEMINI_API_KEY: "test-gemini-key",
 	GOOGLE_SERVICE_ACCOUNT: '{"type":"service_account"}',
 	sushanshan_bot: {} as KVNamespace,
-	// biome-ignore lint/suspicious/noExplicitAny: mock binding for test
-	ANSWER_QUESTION_WORKFLOW: { create: mockWorkflowCreate } as any,
+	ANSWER_QUESTION_WORKFLOW: {
+		create: mockWorkflowCreate,
+	} as unknown as Workflow<WorkflowParams>,
 };
 
 const mockExecutionCtx = {
@@ -61,6 +68,27 @@ function postRequest(body: unknown) {
 		},
 		body: JSON.stringify(body),
 	});
+}
+
+function guildAskInteraction(question = "What is this?") {
+	return {
+		type: 2,
+		token: "interaction-token",
+		guild_id: "guild-123",
+		channel_id: "channel-123",
+		member: {
+			user: {
+				id: "user-123",
+			},
+		},
+		data: {
+			name: "ask",
+			options: [
+				{ name: "ignored", type: 3, value: "not the question" },
+				{ name: "question", type: 3, value: question },
+			],
+		},
+	};
 }
 
 describe("index", () => {
@@ -96,13 +124,7 @@ describe("index", () => {
 			mockWorkflowCreate.mockResolvedValue(undefined);
 
 			const res = await app.fetch(
-				postRequest({
-					type: 2,
-					token: "interaction-token",
-					data: {
-						options: [{ value: "What is this?" }],
-					},
-				}),
+				postRequest(guildAskInteraction()),
 				mockEnv,
 				mockExecutionCtx,
 			);
@@ -114,44 +136,19 @@ describe("index", () => {
 					token: "interaction-token",
 					message: "What is this?",
 					requestId: "req_test_123",
+					conversationKey: expect.stringMatching(/^[0-9a-f]{64}$/),
 				},
 			});
+			expect(
+				JSON.stringify(mockWorkflowCreate.mock.calls[0]?.[0]?.params),
+			).not.toContain("user-123");
 		});
 
-		it("returns error response when body.data is missing", async () => {
-			const res = await app.fetch(
-				postRequest({ type: 2, token: "t" }),
-				mockEnv,
-				mockExecutionCtx,
-			);
-
-			expect(res.status).toBe(200);
-			const json = (await res.json()) as ErrorResponseBody;
-			expect(json.data.embeds[0].description).toBe(
-				"Invalid Discord interaction: missing data",
-			);
-		});
-
-		it("returns error response when options are missing", async () => {
-			const res = await app.fetch(
-				postRequest({ type: 2, token: "t", data: {} }),
-				mockEnv,
-				mockExecutionCtx,
-			);
-
-			expect(res.status).toBe(200);
-			const json = (await res.json()) as ErrorResponseBody;
-			expect(json.data.embeds[0].description).toBe(
-				"Invalid Discord interaction: missing options",
-			);
-		});
-
-		it("returns error response when question is empty", async () => {
+		it("returns error response for an invalid command payload", async () => {
 			const res = await app.fetch(
 				postRequest({
-					type: 2,
-					token: "t",
-					data: { options: [{ value: "   " }] },
+					...guildAskInteraction(),
+					data: { name: "other", options: [] },
 				}),
 				mockEnv,
 				mockExecutionCtx,
@@ -160,7 +157,7 @@ describe("index", () => {
 			expect(res.status).toBe(200);
 			const json = (await res.json()) as ErrorResponseBody;
 			expect(json.data.embeds[0].description).toBe(
-				"Invalid Discord interaction: question must be a non-empty string",
+				"Invalid Discord interaction: invalid command",
 			);
 		});
 
@@ -168,11 +165,7 @@ describe("index", () => {
 			mockWorkflowCreate.mockRejectedValue(new Error("workflow error"));
 
 			const res = await app.fetch(
-				postRequest({
-					type: 2,
-					token: "t",
-					data: { options: [{ value: "question" }] },
-				}),
+				postRequest(guildAskInteraction("question")),
 				mockEnv,
 				mockExecutionCtx,
 			);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,11 @@
 import { InteractionResponseType, InteractionType } from "discord-interactions";
 import { Hono } from "hono";
 import { loadConfig } from "./config";
-import type { Bindings, DiscordInteractionPayload } from "./contracts";
+import type { Bindings } from "./contracts";
+import {
+	getInteractionType,
+	parseDiscordAskCommand,
+} from "./discord/interaction";
 import { runHealthCheck } from "./health";
 import { verifyDiscordInteraction } from "./middleware/verifyDiscordInteraction";
 import { errorResponse } from "./responses/errorResponse";
@@ -13,37 +17,15 @@ export { AnswerQuestionWorkflow } from "./workflows/answerQuestionWorkflow";
 
 const app = new Hono<{ Bindings: Bindings }>();
 
-// Validate Discord command payload structure
-function validateDiscordCommand(body: DiscordInteractionPayload): {
-	question: string;
-} {
-	if (!body?.data) {
-		throw new Error("Invalid Discord interaction: missing data");
-	}
-
-	if (!Array.isArray(body.data.options) || body.data.options.length === 0) {
-		throw new Error("Invalid Discord interaction: missing options");
-	}
-
-	const question = body.data.options[0]?.value;
-	if (typeof question !== "string" || !question.trim()) {
-		throw new Error(
-			"Invalid Discord interaction: question must be a non-empty string",
-		);
-	}
-
-	return { question: question.trim() };
-}
-
 app.get("/", (c) => c.text("Hello Cloudflare Workers!"));
 
 app.post("/", verifyDiscordInteraction, async (c) => {
-	const body = (await c.req.json()) as DiscordInteractionPayload;
 	const requestId = generateRequestId();
 	const log = logger.withContext({ requestId });
 
 	try {
-		switch (body.type) {
+		const body: unknown = await c.req.json();
+		switch (getInteractionType(body)) {
 			// CRITICAL: Discord Interactions Endpoint Requirement
 			// DO NOT REMOVE: Discord sends PING (type=1) requests to verify endpoint availability
 			// and requires PONG (type=1) response for successful verification.
@@ -54,8 +36,8 @@ app.post("/", verifyDiscordInteraction, async (c) => {
 			case InteractionType.APPLICATION_COMMAND: {
 				// Fail fast at the request boundary before creating a Workflow.
 				loadConfig(c.env);
-				// Validate payload structure
-				const { question } = validateDiscordCommand(body);
+				const { token, question, conversationKey } =
+					await parseDiscordAskCommand(body);
 
 				// Start the workflow
 				log.info("Starting AnswerQuestionWorkflow", {
@@ -65,9 +47,10 @@ app.post("/", verifyDiscordInteraction, async (c) => {
 				try {
 					await c.env.ANSWER_QUESTION_WORKFLOW.create({
 						params: {
-							token: body.token,
+							token,
 							message: question,
 							requestId,
+							conversationKey,
 						},
 					});
 				} catch (workflowError) {


### PR DESCRIPTION
Refs #361
Parent: #358

## 概要

Discord Interactionを `unknown` から実行時検証し、会話履歴を利用者＋チャンネル単位で分離するための不透明な `conversationKey` をWorkflow payloadへ追加します。

## 変更前後の責務

### 変更前

- Worker handlerが部分的な境界型へ直接castしていた
- `data.options[0]` を質問として扱い、command名・option名・token・channel・userを検証していなかった
- Workflow payloadに会話主体を識別する情報がなかった

### 変更後

- `src/discord/interaction.ts` がguild/DM両方のInteractionをruntime parseする
- `ask` commandとstring型の `question` optionを名前で解決する
- 質問をtrim後1〜6000文字に制限する
- `guildId:channelId:userId`（DMは固定namespace）をSHA-256化し、64桁hexの `conversationKey` のみWorkflowへ渡す
- Discord command登録にも `max_length: 6000` を設定する

## 互換性・影響

- PING/PONG、署名検証、遅延応答のレスポンス形式は変更しない
- 生のguild/channel/user IDはログやWorkflow payloadへ渡さない
- 現時点では `conversationKey` をWorkflowへ運ぶところまでで、KV履歴キーの切り替えは後続 #362 で行う
- デプロイ後、Discord command定義反映のため `npm run register` が必要

## 検証

- `npm run verify`
  - Biome check成功（既存警告のみ）
  - TypeScript typecheck成功
  - Vitest: 16 files / 215 tests passed
  - Wrangler deploy dry-run成功
- guild/DM正常系
- command・option・token・channel・user欠落
- 空白のみ・6000文字・6001文字
- 同一会話のkey安定性、user/channel差によるkey分離
- Workflow payloadに生Discord IDが含まれないこと
- PINGと署名検証の既存回帰テスト

## ロールバック

このPRのコミットをrevertし、旧command定義を `npm run register` で再登録します。KVキーは本PRでは変更しないため、永続データのmigrationや復旧作業は不要です。

## マージ後の確認

- `npm run register` でcommand定義を反映
- Discord PING、署名検証、`/ask` の遅延応答と回答を実環境で確認
- 確認後に #361 と親Epic #358 の進捗を更新
