### PR TITLE
docs: sync CLAUDE.md after PR #376

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,42 @@ npm run check        # Run Biome formatter + linter with auto-fix
 npm run check:ci     # Run Biome check without writing (for CI)
 npm run typecheck    # Run TypeScript type checking without emitting files
 npm run verify       # Run all non-writing checks, tests, and a deploy dry-run
+npm run test:watch   # Run tests in watch mode
+npm run cf-typegen   # Regenerate worker-configuration.d.ts from wrangler.toml
 ```
 
 ## Architecture
 
-Discord bot on Cloudflare Workers. Uses Google Gemini AI with a Google Sheets knowledge base. Cron health check (every 5 min) reports failures as GitHub Issues.
+Discord bot on Cloudflare Workers. Uses Google Gemini AI with a Google Sheets knowledge base. Cron health check (every 5 min) checks KV / Gemini API / Google service account and reports failures as GitHub Issues.
+
+Request flow:
+
+1. Discord POSTs an interaction to `/`; `verifyDiscordInteraction` middleware verifies the Ed25519 signature.
+2. `PING` gets a `PONG`; `/ask` returns `DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE` immediately (Discord requires a response within 3 s).
+3. The actual work runs in the `AnswerQuestionWorkflow` Cloudflare Workflow: sheet data → conversation history → Gemini streaming (Discord message PATCHed progressively) → save history.
+
+KV access goes through the purpose-specific repositories in `src/repositories/`, never through the raw binding:
+
+- Conversation history (`chat_history:v2:<sha256>`) is keyed per guild+channel+user and expires after `HISTORY_TTL_SECONDS` (default 300). Capped at 20 entries / 64 KiB per key.
+- Sheet cache (`sheet_info:v2:<sha256>`) is keyed by a hash of the spreadsheet ID and sheet names, with a fixed 5-minute TTL (not affected by `HISTORY_TTL_SECONDS`).
+- GitHub Issue deduplication (`error_reported:<fingerprint>`) uses a 1-hour TTL, backed up by a GitHub search as a second layer.
+
+## Project Structure
+
+- `src/index.ts` - Hono app entry point, cron `scheduled` handler, and re-export of `AnswerQuestionWorkflow` so Cloudflare can discover the Workflow class
+- `src/workflows/` - `AnswerQuestionWorkflow` (the answer pipeline) and its shared types
+- `src/repositories/` - purpose-specific KV access: `conversationHistory`, `sheetCache`, `deduplicationStore`
+- `src/clients/` - external service clients: `discord`, `gemini`, `spreadSheet`, `github`, `metrics`
+- `src/discord/` - interaction parsing and conversation-key derivation
+- `src/middleware/` - Discord request signature verification
+- `src/responses/` - Discord error response construction
+- `src/utils/` - logger, retry, request ID, error helpers, sheet compaction
+- `src/config.ts` - env var loading, validation, and production defaults
+- `src/contracts.ts` - `Bindings`, `WorkflowParams`, and other shared types (dependency-free by design)
+- `src/health.ts` - health check invoked by the cron trigger
+- `scripts/` - `register.js` / `commands.js` for Discord slash command registration
+
+Tests live next to their targets as `*.test.ts` and run on `@cloudflare/vitest-pool-workers`.
 
 ## Environment Variables
 
@@ -33,7 +64,13 @@ Optional runtime configuration (current production values are used when omitted)
 - `GEMINI_MODEL`, `GEMINI_SUMMARY_MODEL` - Answer and thinking-summary models
 - `GOOGLE_SPREADSHEET_ID`, `GOOGLE_DATA_SHEET_NAME`, `GOOGLE_DESCRIPTION_SHEET_NAME` - Google Sheets source
 - `GITHUB_REPOSITORY` - Error-report destination in `owner/repository` format
-- `HISTORY_TTL_SECONDS` - Conversation history TTL (60–86400 seconds, default: 300)
+- `HISTORY_TTL_SECONDS` - Conversation history TTL (60–86400 seconds, default: 300). Applies to conversation history only
+
+Cloudflare bindings declared in `wrangler.toml` (typed in `Bindings` in `src/contracts.ts`):
+
+- `sushanshan_bot` - KV namespace for conversation history, sheet cache, and Issue deduplication
+- `ANSWER_QUESTION_WORKFLOW` - Workflow binding for `AnswerQuestionWorkflow`
+- `METRICS` - Analytics Engine dataset (`yangbingyibot_metrics`); optional, metrics are skipped when unbound
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary

CLAUDE.md の内容を PR #376 (refactor: KVを用途別Repositoryへ分割する) のマージ後の実コードと同期します。

## Changes

- **Architecture**: リクエストフロー（Ed25519署名検証 → 即時 DEFERRED レスポンス → `AnswerQuestionWorkflow`）を追記。あわせてキャッシュ戦略を PR #376 の実装に合わせて記載
  - 会話履歴 `chat_history:v2:<sha256>`（guild+channel+user 単位、TTL は `HISTORY_TTL_SECONDS`、20件/64KiB 上限）
  - シートキャッシュ `sheet_info:v2:<sha256>`（スプレッドシートID・シート名のハッシュ単位、TTL 固定5分）
  - Issue重複排除 `error_reported:<fingerprint>`（TTL 1時間 + GitHub検索の2層）
  - KV は生バインディングではなく `src/repositories/` 経由で扱う旨を明記
  - ヘルスチェックの監視対象（KV / Gemini API / サービスアカウント）を追記
- **Project Structure**: セクションを新規追加。PR #376 で追加された `src/repositories/` を含む全ディレクトリを記載
- **Environment Variables**: wrangler.toml の Cloudflare バインディング（`sushanshan_bot` / `ANSWER_QUESTION_WORKFLOW` / `METRICS`）が未記載だったため追加。`HISTORY_TTL_SECONDS` が会話履歴のみに適用される点を明記（PR #376 でシートキャッシュは固定5分TTLに分離）
- **Development Commands**: package.json に存在するが未記載だった `test:watch` と `cf-typegen` を追加

---
Auto-generated by docs-sync workflow.