### PR TITLE
refactor: 外部サービスのerrorとretry policyを統一する

### DIFF
--- a/src/clients/discord.test.ts
+++ b/src/clients/discord.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ExternalServiceError } from "../utils/errors";
 import { createDiscordWebhookClient, DiscordWebhookClient } from "./discord";
 
 describe("DiscordWebhookClient", () => {
@@ -14,13 +15,13 @@ describe("DiscordWebhookClient", () => {
 
 	describe("editOriginalMessage", () => {
 		it("sends PATCH to correct endpoint", async () => {
-			const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+			const mockFetch = vi.fn().mockResolvedValue(new Response(null));
 			globalThis.fetch = mockFetch;
 
 			const client = new DiscordWebhookClient("app-id", "test-token");
 			const result = await client.editOriginalMessage("hello");
 
-			expect(result).toBe(true);
+			expect(result).toBeUndefined();
 			expect(mockFetch).toHaveBeenCalledWith(
 				"https://discord.com/api/v10/webhooks/app-id/test-token/messages/@original",
 				{
@@ -31,54 +32,74 @@ describe("DiscordWebhookClient", () => {
 			);
 		});
 
-		it("returns false on non-ok response", async () => {
-			globalThis.fetch = vi.fn().mockResolvedValue({
-				ok: false,
+		it("throws a typed error on non-ok response", async () => {
+			globalThis.fetch = vi
+				.fn()
+				.mockResolvedValue(new Response("secret body", { status: 500 }));
+
+			const client = new DiscordWebhookClient("app-id", "token");
+			const error = await client
+				.editOriginalMessage("content")
+				.catch((caught) => caught);
+
+			expect(error).toBeInstanceOf(ExternalServiceError);
+			expect(error).toMatchObject({
+				service: "discord",
+				operation: "edit original message",
 				status: 500,
-				headers: new Headers(),
+				retryable: true,
 			});
-
-			const client = new DiscordWebhookClient("app-id", "token");
-			const result = await client.editOriginalMessage("content");
-
-			expect(result).toBe(false);
+			expect(error.message).not.toContain("secret body");
 		});
 
-		it("waits on 429 rate limit with Retry-After header", async () => {
-			globalThis.fetch = vi.fn().mockResolvedValue({
-				ok: false,
+		it("carries Retry-After on a 429 without sleeping in the client", async () => {
+			globalThis.fetch = vi.fn().mockResolvedValue(
+				new Response(null, {
+					status: 429,
+					headers: { "Retry-After": "0.1" },
+				}),
+			);
+
+			const client = new DiscordWebhookClient("app-id", "token");
+			const error = await client
+				.editOriginalMessage("content")
+				.catch((caught) => caught);
+
+			expect(error).toMatchObject({
 				status: 429,
-				headers: new Headers({ "Retry-After": "0.1" }),
+				retryable: true,
+				retryAfterMs: 100,
 			});
-
-			const client = new DiscordWebhookClient("app-id", "token");
-			const start = Date.now();
-			const result = await client.editOriginalMessage("content");
-			const elapsed = Date.now() - start;
-
-			expect(result).toBe(false);
-			expect(elapsed).toBeGreaterThanOrEqual(80);
 		});
 
-		it("returns false on fetch error", async () => {
-			globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+		it("normalizes network errors without exposing their message", async () => {
+			globalThis.fetch = vi
+				.fn()
+				.mockRejectedValue(new Error("Network error with test-token"));
 
 			const client = new DiscordWebhookClient("app-id", "token");
-			const result = await client.editOriginalMessage("content");
+			const error = await client
+				.editOriginalMessage("content")
+				.catch((caught) => caught);
 
-			expect(result).toBe(false);
+			expect(error).toMatchObject({
+				service: "discord",
+				status: undefined,
+				retryable: true,
+			});
+			expect(error.message).not.toContain("test-token");
 		});
 	});
 
 	describe("postMessage", () => {
 		it("sends POST to correct endpoint", async () => {
-			const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+			const mockFetch = vi.fn().mockResolvedValue(new Response(null));
 			globalThis.fetch = mockFetch;
 
 			const client = new DiscordWebhookClient("app-id", "test-token");
 			const result = await client.postMessage("hello world");
 
-			expect(result).toBe(true);
+			expect(result).toBeUndefined();
 			expect(mockFetch).toHaveBeenCalledWith(
 				"https://discord.com/api/v10/webhooks/app-id/test-token",
 				{
@@ -89,25 +110,47 @@ describe("DiscordWebhookClient", () => {
 			);
 		});
 
-		it("throws error on non-ok response", async () => {
-			globalThis.fetch = vi.fn().mockResolvedValue({
-				ok: false,
-				status: 500,
-			});
+		it.each([
+			[400, false],
+			[401, false],
+			[403, false],
+			[404, false],
+			[408, true],
+			[429, true],
+			[500, true],
+			[503, true],
+		])("classifies status %s with retryable=%s", async (status, retryable) => {
+			globalThis.fetch = vi
+				.fn()
+				.mockResolvedValue(new Response(null, { status }));
 
 			const client = new DiscordWebhookClient("app-id", "token");
-			await expect(client.postMessage("content")).rejects.toThrow(
-				"Discord POST failed with status 500",
-			);
+			const error = await client
+				.postMessage("content")
+				.catch((caught) => caught);
+
+			expect(error).toMatchObject({
+				service: "discord",
+				operation: "post message",
+				status,
+				retryable,
+			});
 		});
 
-		it("throws error on fetch error", async () => {
+		it("normalizes a fetch error", async () => {
 			globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
 
 			const client = new DiscordWebhookClient("app-id", "token");
-			await expect(client.postMessage("content")).rejects.toThrow(
-				"Network error",
-			);
+			const error = await client
+				.postMessage("content")
+				.catch((caught) => caught);
+
+			expect(error).toBeInstanceOf(ExternalServiceError);
+			expect(error).toMatchObject({
+				service: "discord",
+				operation: "post message",
+				retryable: true,
+			});
 		});
 	});
 

--- a/src/clients/discord.ts
+++ b/src/clients/discord.ts
@@ -1,4 +1,7 @@
-import { getErrorMessage } from "../utils/errors";
+import {
+	externalServiceErrorFromResponse,
+	normalizeExternalServiceError,
+} from "../utils/errors";
 import { logger as defaultLogger, type Logger } from "../utils/logger";
 
 const DISCORD_API_BASE = "https://discord.com/api/v10";
@@ -15,9 +18,8 @@ export class DiscordWebhookClient {
 	/**
 	 * Edit the original deferred response message (PATCH).
 	 * Used for streaming updates.
-	 * Non-fatal: logs warnings but does not throw on failure.
 	 */
-	async editOriginalMessage(content: string): Promise<boolean> {
+	async editOriginalMessage(content: string): Promise<void> {
 		try {
 			const res = await fetch(`${this.endpoint}/messages/@original`, {
 				method: "PATCH",
@@ -26,24 +28,21 @@ export class DiscordWebhookClient {
 			});
 
 			if (res.ok) {
-				return true;
+				return;
 			}
 
-			if (res.status === 429) {
-				const retryAfter = res.headers.get("Retry-After");
-				const waitMs = retryAfter ? Number.parseFloat(retryAfter) * 1000 : 2000;
-				this.log.warn("Discord rate limited, waiting", { waitMs });
-				await new Promise((resolve) => setTimeout(resolve, waitMs));
-			} else {
-				this.log.warn("Discord PATCH failed", { statusCode: res.status });
-			}
-
-			return false;
+			throw externalServiceErrorFromResponse(
+				"discord",
+				"edit original message",
+				res,
+				"Discordへの応答送信に失敗しました。",
+			);
 		} catch (error) {
-			this.log.warn("Discord PATCH error", {
-				error: getErrorMessage(error),
+			throw normalizeExternalServiceError(error, {
+				service: "discord",
+				operation: "edit original message",
+				userMessage: "Discordへの応答送信に失敗しました。",
 			});
-			return false;
 		}
 	}
 
@@ -52,19 +51,31 @@ export class DiscordWebhookClient {
 	 * Used for sending responses (e.g., error messages).
 	 * Throws on failure.
 	 */
-	async postMessage(content: string): Promise<boolean> {
-		const res = await fetch(this.endpoint, {
-			method: "POST",
-			body: JSON.stringify({ content }),
-			headers: { "Content-Type": "application/json" },
-		});
+	async postMessage(content: string): Promise<void> {
+		try {
+			const res = await fetch(this.endpoint, {
+				method: "POST",
+				body: JSON.stringify({ content }),
+				headers: { "Content-Type": "application/json" },
+			});
 
-		if (!res.ok) {
-			throw new Error(`Discord POST failed with status ${res.status}`);
+			if (!res.ok) {
+				throw externalServiceErrorFromResponse(
+					"discord",
+					"post message",
+					res,
+					"Discordへのメッセージ送信に失敗しました。",
+				);
+			}
+
+			this.log.info("Discord POST succeeded", { statusCode: res.status });
+		} catch (error) {
+			throw normalizeExternalServiceError(error, {
+				service: "discord",
+				operation: "post message",
+				userMessage: "Discordへのメッセージ送信に失敗しました。",
+			});
 		}
-
-		this.log.info("Discord POST succeeded", { statusCode: res.status });
-		return true;
 	}
 }
 

--- a/src/clients/gemini.test.ts
+++ b/src/clients/gemini.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HistoryEntry } from "../contracts";
+import { ExternalServiceError } from "../utils/errors";
 import type { Logger } from "../utils/logger";
 
 const mockGenerateContent = vi.fn();
@@ -23,6 +24,10 @@ import { createGeminiClient, GeminiClient } from "./gemini";
 describe("GeminiClient", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
 	describe("constructor", () => {
@@ -105,9 +110,10 @@ describe("GeminiClient", () => {
 
 			const client = new GeminiClient("test-api-key");
 
-			await expect(client.ask("q", "s", "d")).rejects.toThrow(
-				"AIからの応答形式が不正です。",
-			);
+			await expect(client.ask("q", "s", "d")).rejects.toMatchObject({
+				userMessage: "AIからの応答形式が不正です。",
+				retryable: false,
+			});
 		});
 
 		it("throws error when response has empty candidates array", async () => {
@@ -117,9 +123,10 @@ describe("GeminiClient", () => {
 
 			const client = new GeminiClient("test-api-key");
 
-			await expect(client.ask("q", "s", "d")).rejects.toThrow(
-				"AIからの応答形式が不正です。",
-			);
+			await expect(client.ask("q", "s", "d")).rejects.toMatchObject({
+				userMessage: "AIからの応答形式が不正です。",
+				retryable: false,
+			});
 		});
 
 		it("throws error when response has no text", async () => {
@@ -135,9 +142,10 @@ describe("GeminiClient", () => {
 
 			const client = new GeminiClient("test-api-key");
 
-			await expect(client.ask("q", "s", "d")).rejects.toThrow(
-				"AIから有効な応答が得られませんでした。",
-			);
+			await expect(client.ask("q", "s", "d")).rejects.toMatchObject({
+				userMessage: "AIから有効な応答が得られませんでした。",
+				retryable: false,
+			});
 		});
 
 		it("includes conversation history in subsequent calls", async () => {
@@ -267,7 +275,10 @@ describe("GeminiClient", () => {
 			const client = new GeminiClient("test-api-key");
 			await expect(
 				client.askStream("q", "s", "d", async () => {}),
-			).rejects.toThrow("AIから有効な応答が得られませんでした。");
+			).rejects.toMatchObject({
+				userMessage: "AIから有効な応答が得られませんでした。",
+				retryable: false,
+			});
 		});
 
 		it("throws on thinking-only response with no response text", async () => {
@@ -279,7 +290,10 @@ describe("GeminiClient", () => {
 			const client = new GeminiClient("test-api-key");
 			await expect(
 				client.askStream("q", "s", "d", async () => {}),
-			).rejects.toThrow("AIから有効な応答が得られませんでした。");
+			).rejects.toMatchObject({
+				userMessage: "AIから有効な応答が得られませんでした。",
+				retryable: false,
+			});
 		});
 
 		it("does not update history if stream fails mid-way", async () => {
@@ -292,7 +306,10 @@ describe("GeminiClient", () => {
 			const client = new GeminiClient("test-api-key");
 			await expect(
 				client.askStream("q", "s", "d", async () => {}),
-			).rejects.toThrow("AI APIへのリクエストに失敗しました。");
+			).rejects.toMatchObject({
+				userMessage: "AI APIへのリクエストに失敗しました。",
+				retryable: true,
+			});
 			expect(client.getHistory()).toEqual([]);
 		});
 
@@ -355,37 +372,38 @@ describe("GeminiClient", () => {
 		});
 	});
 
-	describe("handleUnexpectedError (outer catch)", () => {
+	describe("typed error boundary", () => {
 		describe("ask", () => {
-			it("re-throws errors containing 'API' in message", async () => {
+			it("preserves typed validation errors", async () => {
 				mockGenerateContent.mockResolvedValue({
 					candidates: null,
 				});
 
 				const client = new GeminiClient("test-api-key");
 
-				// "AIからの応答形式が不正です。" thrown in validation, re-thrown by handleUnexpectedError
-				// because it contains "AI"
-				await expect(client.ask("q", "s", "d")).rejects.toThrow(
-					"AIからの応答形式が不正です。",
-				);
+				await expect(client.ask("q", "s", "d")).rejects.toMatchObject({
+					service: "gemini",
+					operation: "validate response",
+					userMessage: "AIからの応答形式が不正です。",
+				});
 			});
 
-			it("converts non-API/AI errors to generic message", async () => {
+			it("converts local errors without message matching", async () => {
 				// Pass null in history to cause a TypeError in buildPrompt's map()
-				// TypeError message doesn't contain "API" or "AI"
 				const client = new GeminiClient("test-api-key", [
 					null as unknown as HistoryEntry,
 				]);
 
-				await expect(client.ask("q", "s", "d")).rejects.toThrow(
-					"AI処理中に予期しないエラーが発生しました。",
-				);
+				await expect(client.ask("q", "s", "d")).rejects.toMatchObject({
+					service: "gemini",
+					retryable: false,
+					userMessage: "AI処理中に予期しないエラーが発生しました。",
+				});
 			});
 		});
 
 		describe("askStream", () => {
-			it("re-throws errors containing 'AI' in message", async () => {
+			it("preserves typed validation errors", async () => {
 				const mockStream = (async function* () {
 					// yields nothing
 				})();
@@ -393,23 +411,89 @@ describe("GeminiClient", () => {
 
 				const client = new GeminiClient("test-api-key");
 
-				// Empty stream triggers "AIから有効な応答が得られませんでした。" which contains "AI"
 				await expect(
 					client.askStream("q", "s", "d", async () => {}),
-				).rejects.toThrow("AIから有効な応答が得られませんでした。");
+				).rejects.toMatchObject({
+					service: "gemini",
+					operation: "validate streamed response",
+					userMessage: "AIから有効な応答が得られませんでした。",
+				});
 			});
 
-			it("converts non-API/AI errors to generic message", async () => {
+			it("converts local errors without message matching", async () => {
 				// Pass null in history to cause a TypeError in buildPrompt's map()
-				// TypeError message doesn't contain "API" or "AI"
 				const client = new GeminiClient("test-api-key", [
 					null as unknown as HistoryEntry,
 				]);
 
 				await expect(
 					client.askStream("q", "s", "d", async () => {}),
-				).rejects.toThrow("AI処理中に予期しないエラーが発生しました。");
+				).rejects.toMatchObject({
+					service: "gemini",
+					retryable: false,
+					userMessage: "AI処理中に予期しないエラーが発生しました。",
+				});
 			});
+		});
+	});
+
+	describe("retry policy", () => {
+		const apiError = (status: number, message: string) =>
+			Object.assign(new Error(message), { name: "ApiError", status });
+
+		it("retries a structured 503 without inspecting its message", async () => {
+			vi.useFakeTimers();
+			mockGenerateContent
+				.mockRejectedValueOnce(
+					apiError(503, "response body without retry keywords"),
+				)
+				.mockResolvedValueOnce({
+					candidates: [{ content: { parts: [{ text: "AI response" }] } }],
+				});
+
+			const promise = new GeminiClient("test-api-key").ask("q", "s", "d");
+			await vi.runAllTimersAsync();
+
+			await expect(promise).resolves.toBe("AI response");
+			expect(mockGenerateContent).toHaveBeenCalledTimes(2);
+		});
+
+		it.each([400, 401, 403, 404])(
+			"does not retry a structured permanent status %s",
+			async (status) => {
+				mockGenerateContent.mockRejectedValue(
+					apiError(status, "rate limit words do not control policy"),
+				);
+
+				const error = await new GeminiClient("test-api-key")
+					.ask("q", "s", "d")
+					.catch((caught) => caught);
+
+				expect(error).toBeInstanceOf(ExternalServiceError);
+				expect(error).toMatchObject({
+					status,
+					retryable: false,
+				});
+				expect(mockGenerateContent).toHaveBeenCalledTimes(1);
+			},
+		);
+
+		it("maps status 429 to a stable user message without exposing the SDK body", async () => {
+			mockGenerateContent.mockRejectedValue(
+				apiError(429, "secret response body"),
+			);
+
+			const error = await new GeminiClient("test-api-key")
+				.ask("q", "s", "d")
+				.catch((caught) => caught);
+
+			expect(error).toMatchObject({
+				status: 429,
+				retryable: true,
+				userMessage:
+					"API使用制限に達しました。しばらく待ってから再度お試しください。",
+			});
+			expect(error.message).not.toContain("secret response body");
 		});
 	});
 

--- a/src/clients/gemini.ts
+++ b/src/clients/gemini.ts
@@ -5,7 +5,11 @@ import {
 } from "@google/genai";
 import { DEFAULT_RUNTIME_CONFIG } from "../config";
 import type { HistoryEntry } from "../contracts";
-import { getErrorMessage } from "../utils/errors";
+import {
+	ExternalServiceError,
+	getExternalErrorLogContext,
+	normalizeExternalServiceError,
+} from "../utils/errors";
 import { logger as defaultLogger, type Logger } from "../utils/logger";
 import { withRetry } from "../utils/retry";
 
@@ -48,55 +52,74 @@ export class GeminiClient {
 ${historyText ? `会話履歴:\n${historyText}\n\n` : ""}質問: ${input}`;
 	}
 
-	private isRetryableError(error: Error): boolean {
-		const msg = error.message.toLowerCase();
-		return (
-			msg.includes("quota") ||
-			msg.includes("rate limit") ||
-			msg.includes("network") ||
-			msg.includes("timeout") ||
-			msg.includes("500") ||
-			msg.includes("503")
+	private userMessageForStatus(status: number | undefined): string {
+		if (status === 429) {
+			return "API使用制限に達しました。しばらく待ってから再度お試しください。";
+		}
+		if (status === 401 || status === 403) {
+			return "API認証エラーが発生しました。";
+		}
+		return "AI APIへのリクエストに失敗しました。";
+	}
+
+	private normalizeGeminiError(
+		error: unknown,
+		operation: string,
+	): ExternalServiceError {
+		const normalized = normalizeExternalServiceError(error, {
+			service: "gemini",
+			operation,
+			userMessage: "AI APIへのリクエストに失敗しました。",
+		});
+		if (normalized.service !== "gemini") {
+			return normalized;
+		}
+
+		return new ExternalServiceError({
+			service: normalized.service,
+			operation: normalized.operation,
+			status: normalized.status,
+			retryable: normalized.retryable,
+			userMessage: this.userMessageForStatus(normalized.status),
+			retryAfterMs: normalized.retryAfterMs,
+			cause: normalized.cause,
+		});
+	}
+
+	private async executeRequest<T>(
+		operation: string,
+		request: () => Promise<T>,
+	): Promise<T> {
+		return withRetry(
+			async () => {
+				try {
+					return await request();
+				} catch (error) {
+					throw this.normalizeGeminiError(error, operation);
+				}
+			},
+			this.RETRY_CONFIG,
+			undefined,
+			this.log,
 		);
 	}
 
-	private handleGeminiError(error: unknown): never {
-		this.log.error("Gemini API request failed", {
-			error: getErrorMessage(error),
-		});
-
-		if (error instanceof Error) {
-			if (
-				error.message.includes("quota") ||
-				error.message.includes("rate limit")
-			) {
-				throw new Error(
-					"API使用制限に達しました。しばらく待ってから再度お試しください。",
-				);
-			}
-			if (
-				error.message.includes("invalid") ||
-				error.message.includes("API key")
-			) {
-				throw new Error("API認証エラーが発生しました。");
-			}
-		}
-
-		throw new Error("AI APIへのリクエストに失敗しました。");
-	}
-
 	private handleUnexpectedError(error: unknown, context: string): never {
-		if (
-			error instanceof Error &&
-			(error.message.includes("API") || error.message.includes("AI"))
-		) {
+		if (error instanceof ExternalServiceError) {
 			throw error;
 		}
 
-		this.log.error(`Unexpected error in ${context}`, {
-			error: getErrorMessage(error),
+		const normalized = normalizeExternalServiceError(error, {
+			service: "gemini",
+			operation: context,
+			retryable: false,
+			userMessage: "AI処理中に予期しないエラーが発生しました。",
 		});
-		throw new Error("AI処理中に予期しないエラーが発生しました。");
+		this.log.error("Unexpected Gemini client error", {
+			context,
+			...getExternalErrorLogContext(normalized),
+		});
+		throw normalized;
 	}
 
 	// トークン使用量を記録する。入力トークンがコストの大半を占めるため、
@@ -148,50 +171,46 @@ ${historyText ? `会話履歴:\n${historyText}\n\n` : ""}質問: ${input}`;
 		try {
 			const fullPrompt = this.buildPrompt(input, sheet, description);
 
-			let result: GenerateContentResponse;
-			try {
-				// Add retry logic with exponential backoff
-				this.log.info("Gemini API request starting");
-				const startTime = Date.now();
-				result = await withRetry(
-					async () => {
-						return await this.client.models.generateContent({
-							model: this.modelName,
-							contents: fullPrompt,
-							config: generationConfig,
-						});
-					},
-					this.RETRY_CONFIG,
-					this.isRetryableError,
-					this.log,
-				);
-				this.log.info("Gemini API completed", {
-					durationMs: Date.now() - startTime,
-				});
-				this.logUsage(result.usageMetadata, "generate");
-			} catch (error) {
-				this.handleGeminiError(error);
-			}
+			this.log.info("Gemini API request starting");
+			const startTime = Date.now();
+			const result: GenerateContentResponse = await this.executeRequest(
+				"generate content",
+				async () => {
+					return await this.client.models.generateContent({
+						model: this.modelName,
+						contents: fullPrompt,
+						config: generationConfig,
+					});
+				},
+			);
+			this.log.info("Gemini API completed", {
+				durationMs: Date.now() - startTime,
+			});
+			this.logUsage(result.usageMetadata, "generate");
 
 			// Validate response structure
-			if (
-				!result.candidates ||
-				!result.candidates[0] ||
-				!result.candidates[0].content ||
-				!result.candidates[0].content.parts ||
-				!result.candidates[0].content.parts[0]
-			) {
-				this.log.error("Invalid Gemini response structure", {
-					result: JSON.stringify(result),
+			if (!result.candidates?.[0]?.content?.parts?.[0]) {
+				const error = new ExternalServiceError({
+					service: "gemini",
+					operation: "validate response",
+					retryable: false,
+					userMessage: "AIからの応答形式が不正です。",
 				});
-				throw new Error("AIからの応答形式が不正です。");
+				this.log.error("Invalid Gemini response structure", {
+					...getExternalErrorLogContext(error),
+				});
+				throw error;
 			}
 
 			const response = result.candidates[0].content.parts[0].text;
 
 			if (!response || typeof response !== "string" || !response.trim()) {
-				this.log.error("Empty or invalid text in Gemini response");
-				throw new Error("AIから有効な応答が得られませんでした。");
+				throw new ExternalServiceError({
+					service: "gemini",
+					operation: "validate response text",
+					retryable: false,
+					userMessage: "AIから有効な応答が得られませんでした。",
+				});
 			}
 
 			this.addToHistory(input, response);
@@ -217,23 +236,21 @@ ${historyText ? `会話履歴:\n${historyText}\n\n` : ""}質問: ${input}`;
 			let fullText = "";
 			let usage: GenerateContentResponseUsageMetadata | undefined;
 
+			this.log.info("Gemini streaming API request starting");
+			const startTime = Date.now();
+
+			const stream = await this.executeRequest(
+				"start content stream",
+				async () => {
+					return await this.client.models.generateContentStream({
+						model: this.modelName,
+						contents: fullPrompt,
+						config: streamGenerationConfig,
+					});
+				},
+			);
+
 			try {
-				this.log.info("Gemini streaming API request starting");
-				const startTime = Date.now();
-
-				const stream = await withRetry(
-					async () => {
-						return await this.client.models.generateContentStream({
-							model: this.modelName,
-							contents: fullPrompt,
-							config: streamGenerationConfig,
-						});
-					},
-					this.RETRY_CONFIG,
-					this.isRetryableError,
-					this.log,
-				);
-
 				for await (const chunk of stream) {
 					// ストリーミングでは使用量は終盤のチャンクに載るため、最後の値を採用する
 					if (chunk.usageMetadata) {
@@ -259,12 +276,16 @@ ${historyText ? `会話履歴:\n${historyText}\n\n` : ""}質問: ${input}`;
 				});
 				this.logUsage(usage, "stream");
 			} catch (error) {
-				this.handleGeminiError(error);
+				throw this.normalizeGeminiError(error, "consume content stream");
 			}
 
-			if (!fullText || !fullText.trim()) {
-				this.log.error("Empty text from Gemini streaming response");
-				throw new Error("AIから有効な応答が得られませんでした。");
+			if (!fullText?.trim()) {
+				throw new ExternalServiceError({
+					service: "gemini",
+					operation: "validate streamed response",
+					retryable: false,
+					userMessage: "AIから有効な応答が得られませんでした。",
+				});
 			}
 
 			this.addToHistory(input, fullText);

--- a/src/clients/github.test.ts
+++ b/src/clients/github.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ExternalServiceError } from "../utils/errors";
 import {
 	createGitHubIssueClient,
 	type ErrorReport,
@@ -14,6 +15,7 @@ describe("GitHubIssueClient", () => {
 
 	afterEach(() => {
 		globalThis.fetch = originalFetch;
+		vi.useRealTimers();
 	});
 
 	const sampleReport: ErrorReport = {
@@ -82,7 +84,7 @@ describe("GitHubIssueClient", () => {
 			const client = new GitHubIssueClient("test-token");
 			const result = await client.createIssue(sampleReport, "test-fingerprint");
 
-			expect(result).toBe(true);
+			expect(result).toBeUndefined();
 			expect(mockFetch).toHaveBeenCalledTimes(1);
 
 			const [url, options] = mockFetch.mock.calls[0];
@@ -142,25 +144,41 @@ describe("GitHubIssueClient", () => {
 			);
 		});
 
-		it("returns false on API error", async () => {
-			globalThis.fetch = vi.fn().mockResolvedValue({
-				ok: false,
-				status: 403,
-			});
+		it("throws a typed non-retryable API error", async () => {
+			globalThis.fetch = vi
+				.fn()
+				.mockResolvedValue(new Response("secret body", { status: 403 }));
 
 			const client = new GitHubIssueClient("test-token");
-			const result = await client.createIssue(sampleReport, "fp");
+			const error = await client
+				.createIssue(sampleReport, "fp")
+				.catch((caught) => caught);
 
-			expect(result).toBe(false);
+			expect(error).toBeInstanceOf(ExternalServiceError);
+			expect(error).toMatchObject({
+				service: "github",
+				operation: "create issue",
+				status: 403,
+				retryable: false,
+			});
+			expect(error.message).not.toContain("secret body");
+			expect(globalThis.fetch).toHaveBeenCalledTimes(1);
 		});
 
-		it("returns false on network error", async () => {
+		it("does not retry an ambiguous POST network error", async () => {
 			globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
 
 			const client = new GitHubIssueClient("test-token");
-			const result = await client.createIssue(sampleReport, "fp");
+			const error = await client
+				.createIssue(sampleReport, "fp")
+				.catch((caught) => caught);
 
-			expect(result).toBe(false);
+			expect(error).toMatchObject({
+				service: "github",
+				operation: "create issue",
+				retryable: true,
+			});
+			expect(globalThis.fetch).toHaveBeenCalledTimes(1);
 		});
 
 		it("omits step row from body when step is undefined", async () => {
@@ -211,25 +229,39 @@ describe("GitHubIssueClient", () => {
 			expect(result).toBe(false);
 		});
 
-		it("returns false (fail-open) on API error", async () => {
-			globalThis.fetch = vi.fn().mockResolvedValue({
-				ok: false,
-				status: 403,
-			});
+		it("throws without retrying a permanent API error", async () => {
+			globalThis.fetch = vi
+				.fn()
+				.mockResolvedValue(new Response(null, { status: 403 }));
 
 			const client = new GitHubIssueClient("test-token");
-			const result = await client.isDuplicate("test-fingerprint");
+			const error = await client
+				.isDuplicate("test-fingerprint")
+				.catch((caught) => caught);
 
-			expect(result).toBe(false);
+			expect(error).toMatchObject({
+				status: 403,
+				retryable: false,
+			});
+			expect(globalThis.fetch).toHaveBeenCalledTimes(1);
 		});
 
-		it("returns false (fail-open) on network error", async () => {
-			globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+		it("retries a network error before succeeding", async () => {
+			vi.useFakeTimers();
+			globalThis.fetch = vi
+				.fn()
+				.mockRejectedValueOnce(new Error("Network error"))
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => ({ total_count: 0 }),
+				});
 
 			const client = new GitHubIssueClient("test-token");
-			const result = await client.isDuplicate("test-fingerprint");
+			const promise = client.isDuplicate("test-fingerprint");
+			await vi.runAllTimersAsync();
 
-			expect(result).toBe(false);
+			await expect(promise).resolves.toBe(false);
+			expect(globalThis.fetch).toHaveBeenCalledTimes(2);
 		});
 	});
 

--- a/src/clients/github.ts
+++ b/src/clients/github.ts
@@ -1,8 +1,18 @@
 import { DEFAULT_RUNTIME_CONFIG, type GitHubRepositoryConfig } from "../config";
-import { getErrorMessage } from "../utils/errors";
+import {
+	externalServiceErrorFromResponse,
+	normalizeExternalServiceError,
+} from "../utils/errors";
 import { logger as defaultLogger, type Logger } from "../utils/logger";
+import { withRetry } from "../utils/retry";
 
 const GITHUB_API_BASE = "https://api.github.com";
+const GITHUB_RETRY_CONFIG = {
+	maxAttempts: 3,
+	initialDelayMs: 500,
+	maxDelayMs: 5000,
+	backoffMultiplier: 2,
+};
 
 export interface ErrorReport {
 	errorMessage: string;
@@ -42,6 +52,47 @@ export class GitHubIssueClient {
 		this.repository = repository;
 	}
 
+	private async request(
+		operation: string,
+		url: string,
+		init: RequestInit,
+		retry: boolean,
+	): Promise<Response> {
+		const execute = async () => {
+			try {
+				const response = await fetch(url, init);
+				if (!response.ok) {
+					throw externalServiceErrorFromResponse(
+						"github",
+						operation,
+						response,
+						"GitHubへの障害報告に失敗しました。",
+					);
+				}
+				return response;
+			} catch (error) {
+				throw normalizeExternalServiceError(error, {
+					service: "github",
+					operation,
+					userMessage: "GitHubへの障害報告に失敗しました。",
+				});
+			}
+		};
+
+		return retry
+			? withRetry(execute, GITHUB_RETRY_CONFIG, undefined, this.log)
+			: execute();
+	}
+
+	private headers(contentType = false): Record<string, string> {
+		return {
+			Authorization: `Bearer ${this.token}`,
+			Accept: "application/vnd.github+json",
+			"User-Agent": "yangbingyibot-error-reporter",
+			...(contentType ? { "Content-Type": "application/json" } : {}),
+		};
+	}
+
 	/**
 	 * Generate a fingerprint from an error message by removing dynamic elements.
 	 * This allows grouping similar errors together for deduplication.
@@ -59,192 +110,150 @@ export class GitHubIssueClient {
 
 	/**
 	 * Check if a GitHub Issue with the same fingerprint already exists (open).
-	 * Fail-open: returns false on any error so that a new issue is created.
+	 * Read-only requests use the shared retry policy.
 	 */
 	async isDuplicate(fingerprint: string): Promise<boolean> {
 		try {
 			const query = encodeURIComponent(
 				`repo:${this.repository.fullName} is:issue is:open label:auto-reported "${fingerprint}"`,
 			);
-			const res = await fetch(
+			const res = await this.request(
+				"search issues",
 				`${GITHUB_API_BASE}/search/issues?q=${query}&per_page=1`,
 				{
-					headers: {
-						Authorization: `Bearer ${this.token}`,
-						Accept: "application/vnd.github+json",
-						"User-Agent": "yangbingyibot-error-reporter",
-					},
+					headers: this.headers(),
 				},
+				true,
 			);
 
-			if (!res.ok) {
-				this.log.warn("GitHub issue search failed", {
-					statusCode: res.status,
-				});
-				return false;
-			}
-
 			const data = (await res.json()) as { total_count: number };
+			if (typeof data.total_count !== "number") {
+				throw new Error("Invalid GitHub search response");
+			}
 			return data.total_count > 0;
 		} catch (error) {
-			this.log.warn("GitHub issue search error (fail-open)", {
-				error: getErrorMessage(error),
+			throw normalizeExternalServiceError(error, {
+				service: "github",
+				operation: "parse issue search response",
+				retryable: false,
+				userMessage: "GitHubへの障害報告に失敗しました。",
 			});
-			return false;
 		}
 	}
 
 	/**
 	 * Create a GitHub Issue for a health check failure.
-	 * Non-fatal: logs warnings but does not throw on failure.
+	 * POST is attempted once because retrying an ambiguous network failure could
+	 * create duplicate issues. Callers keep this operation non-fatal.
 	 */
 	async createHealthCheckIssue(
 		report: HealthCheckReport,
 		fingerprint: string,
-	): Promise<boolean> {
-		try {
-			const failedNames = report.failedChecks.map((c) => c.name).join(", ");
-			const title = `[Health Check] ${failedNames} 異常検知`;
+	): Promise<void> {
+		const failedNames = report.failedChecks.map((c) => c.name).join(", ");
+		const title = `[Health Check] ${failedNames} 異常検知`;
 
-			const allChecks = [
-				...report.failedChecks.map((c) => ({
-					name: c.name,
-					status: "❌ 異常",
-					durationMs: c.durationMs,
-					detail: c.error,
-				})),
-				...report.passedChecks.map((c) => ({
-					name: c.name,
-					status: "✅ 正常",
-					durationMs: c.durationMs,
-					detail: "-",
-				})),
-			];
+		const allChecks = [
+			...report.failedChecks.map((c) => ({
+				name: c.name,
+				status: "❌ 異常",
+				durationMs: c.durationMs,
+				detail: c.error,
+			})),
+			...report.passedChecks.map((c) => ({
+				name: c.name,
+				status: "✅ 正常",
+				durationMs: c.durationMs,
+				detail: "-",
+			})),
+		];
 
-			const tableRows = allChecks
-				.map(
-					(c) =>
-						`| ${c.name} | ${c.status} | ${c.durationMs}ms | ${c.detail} |`,
-				)
-				.join("\n");
+		const tableRows = allChecks
+			.map(
+				(c) => `| ${c.name} | ${c.status} | ${c.durationMs}ms | ${c.detail} |`,
+			)
+			.join("\n");
 
-			const body = [
-				"## ヘルスチェック結果",
-				"",
-				"| チェック | 状態 | レイテンシ | 詳細 |",
-				"| --- | --- | --- | --- |",
-				tableRows,
-				"",
-				"## Fingerprint",
-				"",
-				`\`${fingerprint}\``,
-				"",
-				`**検知時刻:** ${report.timestamp}`,
-				"",
-				"---",
-				"*This issue was automatically created by the health check monitoring system.*",
-			].join("\n");
+		const body = [
+			"## ヘルスチェック結果",
+			"",
+			"| チェック | 状態 | レイテンシ | 詳細 |",
+			"| --- | --- | --- | --- |",
+			tableRows,
+			"",
+			"## Fingerprint",
+			"",
+			`\`${fingerprint}\``,
+			"",
+			`**検知時刻:** ${report.timestamp}`,
+			"",
+			"---",
+			"*This issue was automatically created by the health check monitoring system.*",
+		].join("\n");
 
-			const res = await fetch(
-				`${GITHUB_API_BASE}/repos/${this.repository.fullName}/issues`,
-				{
-					method: "POST",
-					headers: {
-						Authorization: `Bearer ${this.token}`,
-						Accept: "application/vnd.github+json",
-						"User-Agent": "yangbingyibot-error-reporter",
-						"Content-Type": "application/json",
-					},
-					body: JSON.stringify({
-						title,
-						body,
-						labels: ["health-check", "auto-reported"],
-					}),
-				},
-			);
+		await this.request(
+			"create health check issue",
+			`${GITHUB_API_BASE}/repos/${this.repository.fullName}/issues`,
+			{
+				method: "POST",
+				headers: this.headers(true),
+				body: JSON.stringify({
+					title,
+					body,
+					labels: ["health-check", "auto-reported"],
+				}),
+			},
+			false,
+		);
 
-			if (!res.ok) {
-				this.log.warn("GitHub health check issue creation failed", {
-					statusCode: res.status,
-				});
-				return false;
-			}
-
-			this.log.info("GitHub health check issue created successfully");
-			return true;
-		} catch (error) {
-			this.log.warn("GitHub health check issue creation error", {
-				error: getErrorMessage(error),
-			});
-			return false;
-		}
+		this.log.info("GitHub health check issue created successfully");
 	}
 
 	/**
 	 * Create a GitHub Issue for an error report.
-	 * Non-fatal: logs warnings but does not throw on failure.
+	 * POST is attempted once because retrying an ambiguous network failure could
+	 * create duplicate issues. Callers keep this operation non-fatal.
 	 */
-	async createIssue(
-		report: ErrorReport,
-		fingerprint: string,
-	): Promise<boolean> {
-		try {
-			const title = `[Auto] Worker Error: ${report.errorMessage.slice(0, 80)}`;
+	async createIssue(report: ErrorReport, fingerprint: string): Promise<void> {
+		const title = `[Auto] Worker Error: ${report.errorMessage.slice(0, 80)}`;
 
-			const body = [
-				"## Error Details",
-				"",
-				"| Field | Value |",
-				"| --- | --- |",
-				`| **Error** | \`${report.errorMessage}\` |`,
-				`| **Request ID** | \`${report.requestId}\` |`,
-				`| **Workflow ID** | \`${report.workflowId}\` |`,
-				...(report.step ? [`| **Step** | \`${report.step}\` |`] : []),
-				`| **Duration** | ${report.durationMs}ms |`,
-				`| **Steps Completed** | ${report.stepCount} |`,
-				`| **Timestamp** | ${report.timestamp} |`,
-				"",
-				"## Fingerprint",
-				"",
-				`\`${fingerprint}\``,
-				"",
-				"---",
-				"*This issue was automatically created by the error monitoring system.*",
-			].join("\n");
+		const body = [
+			"## Error Details",
+			"",
+			"| Field | Value |",
+			"| --- | --- |",
+			`| **Error** | \`${report.errorMessage}\` |`,
+			`| **Request ID** | \`${report.requestId}\` |`,
+			`| **Workflow ID** | \`${report.workflowId}\` |`,
+			...(report.step ? [`| **Step** | \`${report.step}\` |`] : []),
+			`| **Duration** | ${report.durationMs}ms |`,
+			`| **Steps Completed** | ${report.stepCount} |`,
+			`| **Timestamp** | ${report.timestamp} |`,
+			"",
+			"## Fingerprint",
+			"",
+			`\`${fingerprint}\``,
+			"",
+			"---",
+			"*This issue was automatically created by the error monitoring system.*",
+		].join("\n");
 
-			const res = await fetch(
-				`${GITHUB_API_BASE}/repos/${this.repository.fullName}/issues`,
-				{
-					method: "POST",
-					headers: {
-						Authorization: `Bearer ${this.token}`,
-						Accept: "application/vnd.github+json",
-						"User-Agent": "yangbingyibot-error-reporter",
-						"Content-Type": "application/json",
-					},
-					body: JSON.stringify({
-						title,
-						body,
-						labels: ["bug", "auto-reported"],
-					}),
-				},
-			);
+		await this.request(
+			"create issue",
+			`${GITHUB_API_BASE}/repos/${this.repository.fullName}/issues`,
+			{
+				method: "POST",
+				headers: this.headers(true),
+				body: JSON.stringify({
+					title,
+					body,
+					labels: ["bug", "auto-reported"],
+				}),
+			},
+			false,
+		);
 
-			if (!res.ok) {
-				this.log.warn("GitHub issue creation failed", {
-					statusCode: res.status,
-				});
-				return false;
-			}
-
-			this.log.info("GitHub issue created successfully");
-			return true;
-		} catch (error) {
-			this.log.warn("GitHub issue creation error", {
-				error: getErrorMessage(error),
-			});
-			return false;
-		}
+		this.log.info("GitHub issue created successfully");
 	}
 }
 

--- a/src/clients/spreadSheet.test.ts
+++ b/src/clients/spreadSheet.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ExternalServiceError } from "../utils/errors";
 import type { Logger } from "../utils/logger";
 
 const mockGetGoogleAuthToken = vi.fn();
@@ -98,6 +99,10 @@ describe("spreadSheet", () => {
 		mockLoadCells.mockResolvedValue(undefined);
 	});
 
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	describe("getSheetData", () => {
 		it("returns sheet info and description on success", async () => {
 			setupSheets();
@@ -151,21 +156,34 @@ describe("spreadSheet", () => {
 
 	describe("parseServiceAccount (via getSheetData)", () => {
 		it("throws on invalid JSON", async () => {
-			await expect(getSheetData("not-json", mockLogger)).rejects.toThrow(
-				"スプレッドシート情報の取得中にエラーが発生しました。",
-			);
+			await expect(
+				getSheetData("not-json PRIVATE_KEY_SECRET", mockLogger),
+			).rejects.toMatchObject({
+				service: "sheets",
+				operation: "parse service account",
+				retryable: false,
+				userMessage: "Google認証設定が不正です。",
+			});
 		});
 
 		it("throws when client_email is missing", async () => {
 			await expect(
 				getSheetData(JSON.stringify({ private_key: "key" }), mockLogger),
-			).rejects.toThrow("スプレッドシート情報の取得中にエラーが発生しました。");
+			).rejects.toMatchObject({
+				operation: "validate service account",
+				retryable: false,
+				userMessage: "Google認証設定が不正です。",
+			});
 		});
 
 		it("throws when private_key is missing", async () => {
 			await expect(
 				getSheetData(JSON.stringify({ client_email: "a@b.com" }), mockLogger),
-			).rejects.toThrow("スプレッドシート情報の取得中にエラーが発生しました。");
+			).rejects.toMatchObject({
+				operation: "validate service account",
+				retryable: false,
+				userMessage: "Google認証設定が不正です。",
+			});
 		});
 	});
 
@@ -175,20 +193,55 @@ describe("spreadSheet", () => {
 
 			await expect(
 				getSheetData(validServiceAccount, mockLogger),
-			).rejects.toThrow("スプレッドシート情報の取得中にエラーが発生しました。");
+			).rejects.toMatchObject({
+				service: "sheets",
+				operation: "authenticate",
+				retryable: false,
+				userMessage: "Google認証に失敗しました。",
+			});
 		});
 	});
 
 	describe("loadInfo failure", () => {
 		it("throws user-friendly error when loadInfo fails", async () => {
 			setupSheets();
-			mockLoadInfo.mockRejectedValue(new Error("403 Forbidden"));
-
-			await expect(
-				getSheetData(validServiceAccount, mockLogger),
-			).rejects.toThrow(
-				"スプレッドシートへのアクセスに失敗しました。権限を確認してください。",
+			mockLoadInfo.mockRejectedValue(
+				Object.assign(new Error("secret response body"), { status: 403 }),
 			);
+
+			const error = await getSheetData(validServiceAccount, mockLogger).catch(
+				(caught) => caught,
+			);
+
+			expect(error).toBeInstanceOf(ExternalServiceError);
+			expect(error).toMatchObject({
+				operation: "load spreadsheet",
+				status: 403,
+				retryable: false,
+				userMessage:
+					"スプレッドシートへのアクセスに失敗しました。権限を確認してください。",
+			});
+			expect(error.message).not.toContain("secret response body");
+			expect(mockLoadInfo).toHaveBeenCalledTimes(1);
+		});
+
+		it("retries a structured 503", async () => {
+			vi.useFakeTimers();
+			setupSheets();
+			mockLoadInfo
+				.mockRejectedValueOnce(
+					Object.assign(new Error("unavailable"), { status: 503 }),
+				)
+				.mockResolvedValueOnce(undefined);
+
+			const promise = getSheetData(validServiceAccount, mockLogger);
+			await vi.runAllTimersAsync();
+
+			await expect(promise).resolves.toEqual({
+				sheetInfo: "col1\tcol2\nval1\tval2",
+				description: "Bot description",
+			});
+			expect(mockLoadInfo).toHaveBeenCalledTimes(2);
 		});
 	});
 
@@ -198,7 +251,11 @@ describe("spreadSheet", () => {
 
 			await expect(
 				getSheetData(validServiceAccount, mockLogger),
-			).rejects.toThrow("スプレッドシート情報の取得中にエラーが発生しました。");
+			).rejects.toMatchObject({
+				operation: "resolve data sheet",
+				retryable: false,
+				userMessage: "指定されたシートが見つかりません。",
+			});
 		});
 
 		it("throws when CSV is empty", async () => {
@@ -206,7 +263,11 @@ describe("spreadSheet", () => {
 
 			await expect(
 				getSheetData(validServiceAccount, mockLogger),
-			).rejects.toThrow("シートデータのダウンロードに失敗しました。");
+			).rejects.toMatchObject({
+				operation: "validate data sheet",
+				retryable: false,
+				userMessage: "シートデータが空です。",
+			});
 		});
 	});
 });

--- a/src/clients/spreadSheet.ts
+++ b/src/clients/spreadSheet.ts
@@ -4,10 +4,45 @@ import GoogleAuth, {
 import { GoogleSpreadsheet } from "google-spreadsheet";
 import { DEFAULT_RUNTIME_CONFIG, type SpreadsheetConfig } from "../config";
 import { compactSheetCsv } from "../utils/compactSheet";
-import { getErrorMessage } from "../utils/errors";
+import {
+	ExternalServiceError,
+	getExternalErrorLogContext,
+	normalizeExternalServiceError,
+} from "../utils/errors";
 import { logger as defaultLogger, type Logger } from "../utils/logger";
+import { withRetry } from "../utils/retry";
 
 const GOOGLE_SCOPES = ["https://www.googleapis.com/auth/spreadsheets"];
+const SHEETS_RETRY_CONFIG = {
+	maxAttempts: 3,
+	initialDelayMs: 500,
+	maxDelayMs: 5000,
+	backoffMultiplier: 2,
+};
+
+async function executeSheetsRequest<T>(
+	operation: string,
+	userMessage: string,
+	log: Logger,
+	request: () => Promise<T>,
+): Promise<T> {
+	return withRetry(
+		async () => {
+			try {
+				return await request();
+			} catch (error) {
+				throw normalizeExternalServiceError(error, {
+					service: "sheets",
+					operation,
+					userMessage,
+				});
+			}
+		},
+		SHEETS_RETRY_CONFIG,
+		undefined,
+		log,
+	);
+}
 
 // Helper to parse and validate service account JSON
 function parseServiceAccount(serviceAccountJson: string): GoogleKey {
@@ -16,17 +51,26 @@ function parseServiceAccount(serviceAccountJson: string): GoogleKey {
 
 		// Validate required fields
 		if (!parsed.client_email || !parsed.private_key) {
-			throw new Error(
-				"Service account JSON missing required fields (client_email, private_key)",
-			);
+			throw new ExternalServiceError({
+				service: "sheets",
+				operation: "validate service account",
+				retryable: false,
+				userMessage: "Google認証設定が不正です。",
+			});
 		}
 
 		return parsed as GoogleKey;
 	} catch (error) {
-		if (error instanceof SyntaxError) {
-			throw new Error("Invalid service account JSON format");
+		if (error instanceof ExternalServiceError) {
+			throw error;
 		}
-		throw error;
+		throw new ExternalServiceError({
+			service: "sheets",
+			operation: "parse service account",
+			retryable: false,
+			userMessage: "Google認証設定が不正です。",
+			cause: error,
+		});
 	}
 }
 
@@ -38,18 +82,33 @@ async function authenticateGoogle(
 	try {
 		const googleAuth = parseServiceAccount(serviceAccountJson);
 		const oauth = new GoogleAuth(googleAuth, GOOGLE_SCOPES);
-		const token = await oauth.getGoogleAuthToken();
+		const token = await executeSheetsRequest(
+			"authenticate",
+			"Google認証に失敗しました。",
+			log,
+			async () => await oauth.getGoogleAuthToken(),
+		);
 
 		if (!token) {
-			throw new Error("Failed to obtain Google auth token");
+			throw new ExternalServiceError({
+				service: "sheets",
+				operation: "authenticate",
+				retryable: false,
+				userMessage: "Google認証に失敗しました。",
+			});
 		}
 
 		return token;
 	} catch (error) {
 		log.error("Google authentication error", {
-			error: getErrorMessage(error),
+			...getExternalErrorLogContext(error),
 		});
-		throw new Error(`Google authentication failed: ${getErrorMessage(error)}`);
+		throw normalizeExternalServiceError(error, {
+			service: "sheets",
+			operation: "authenticate",
+			retryable: false,
+			userMessage: "Google認証に失敗しました。",
+		});
 	}
 }
 
@@ -67,16 +126,33 @@ async function fetchSheetInfo(
 ): Promise<string> {
 	const sheet = doc.sheetsByTitle[sheetName];
 	if (!sheet) {
-		throw new Error(`Sheet "${sheetName}" not found in spreadsheet`);
+		throw new ExternalServiceError({
+			service: "sheets",
+			operation: "resolve data sheet",
+			retryable: false,
+			userMessage: "指定されたシートが見つかりません。",
+		});
 	}
 
 	try {
-		await sheet.loadHeaderRow(2);
-		const csvBuffer = await sheet.downloadAsCSV();
+		const csvBuffer = await executeSheetsRequest(
+			"download data sheet",
+			"シートデータのダウンロードに失敗しました。",
+			log,
+			async () => {
+				await sheet.loadHeaderRow(2);
+				return sheet.downloadAsCSV();
+			},
+		);
 		const csvContent = new TextDecoder().decode(csvBuffer);
 
 		if (!csvContent || csvContent.trim().length === 0) {
-			throw new Error("Sheet returned empty CSV data");
+			throw new ExternalServiceError({
+				service: "sheets",
+				operation: "validate data sheet",
+				retryable: false,
+				userMessage: "シートデータが空です。",
+			});
 		}
 
 		// CSVはGeminiへの入力トークンの大半を占めるため、渡す前に圧縮する
@@ -89,9 +165,13 @@ async function fetchSheetInfo(
 		return compacted;
 	} catch (error) {
 		log.error("Failed to download sheet as CSV", {
-			error: getErrorMessage(error),
+			...getExternalErrorLogContext(error),
 		});
-		throw new Error("シートデータのダウンロードに失敗しました。");
+		throw normalizeExternalServiceError(error, {
+			service: "sheets",
+			operation: "download data sheet",
+			userMessage: "シートデータのダウンロードに失敗しました。",
+		});
 	}
 }
 
@@ -110,12 +190,17 @@ async function fetchSheetDescription(
 	}
 
 	try {
-		await sheet.loadCells("A1");
+		await executeSheetsRequest(
+			"load description sheet",
+			"シート説明の取得に失敗しました。",
+			log,
+			async () => await sheet.loadCells("A1"),
+		);
 		const cell = sheet.getCellByA1("A1");
 		return cell.value?.toString() || "";
 	} catch (error) {
 		log.warn("Failed to load description cell", {
-			error: getErrorMessage(error),
+			...getExternalErrorLogContext(error),
 		});
 		return "";
 	}
@@ -134,16 +219,12 @@ export async function getSheetData(
 		const doc = new GoogleSpreadsheet(source.id, { token });
 
 		// Load document info
-		try {
-			await doc.loadInfo();
-		} catch (error) {
-			logger.error("Failed to load spreadsheet info", {
-				error: getErrorMessage(error),
-			});
-			throw new Error(
-				"スプレッドシートへのアクセスに失敗しました。権限を確認してください。",
-			);
-		}
+		await executeSheetsRequest(
+			"load spreadsheet",
+			"スプレッドシートへのアクセスに失敗しました。権限を確認してください。",
+			logger,
+			async () => await doc.loadInfo(),
+		);
 
 		// Fetch both sheets in parallel using the same authenticated token
 		const [sheetInfo, description] = await Promise.all([
@@ -153,18 +234,19 @@ export async function getSheetData(
 
 		return { sheetInfo, description };
 	} catch (error) {
-		// Preserve user-friendly errors, wrap others
-		if (
-			error instanceof Error &&
-			(error.message.includes("スプレッドシート") ||
-				error.message.includes("シート"))
-		) {
+		if (error instanceof ExternalServiceError) {
 			throw error;
 		}
 
-		logger.error("Unexpected error in getSheetData", {
-			error: getErrorMessage(error),
+		const normalized = normalizeExternalServiceError(error, {
+			service: "sheets",
+			operation: "get sheet data",
+			retryable: false,
+			userMessage: "スプレッドシート情報の取得中にエラーが発生しました。",
 		});
-		throw new Error("スプレッドシート情報の取得中にエラーが発生しました。");
+		logger.error("Unexpected Sheets client error", {
+			...getExternalErrorLogContext(normalized),
+		});
+		throw normalized;
 	}
 }

--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -73,6 +73,13 @@ describe("health check", () => {
 			expect(env.METRICS.writeDataPoint).toHaveBeenCalledTimes(3);
 			// No GitHub issue creation (fetch called only for Gemini models.list)
 			expect(mockFetch).toHaveBeenCalledTimes(1);
+			expect(mockFetch).toHaveBeenCalledWith(
+				"https://generativelanguage.googleapis.com/v1beta/models",
+				{ headers: { "x-goog-api-key": "test-gemini-key" } },
+			);
+			expect(JSON.stringify(mockFetch.mock.calls)).not.toContain(
+				"?key=test-gemini-key",
+			);
 		});
 	});
 
@@ -143,7 +150,10 @@ describe("health check", () => {
 				(c: CheckResult) => c.name === "gemini",
 			);
 			expect(geminiCheck?.ok).toBe(false);
-			expect(geminiCheck?.error).toBe("HTTP 500");
+			expect(geminiCheck?.error).toBe(
+				"gemini health check failed (status 500)",
+			);
+			expect(geminiCheck?.error).not.toContain("Internal Server Error");
 		});
 
 		it("reports failure on HTTP 401 (invalid key)", async () => {
@@ -166,14 +176,16 @@ describe("health check", () => {
 				(c: CheckResult) => c.name === "gemini",
 			);
 			expect(geminiCheck?.ok).toBe(false);
-			expect(geminiCheck?.error).toBe("HTTP 401");
+			expect(geminiCheck?.error).toBe(
+				"gemini health check failed (status 401)",
+			);
 		});
 	});
 
 	describe("Google SA failure", () => {
 		it("reports failure on invalid JSON", async () => {
 			const env = createMockEnv({
-				GOOGLE_SERVICE_ACCOUNT: "not-json",
+				GOOGLE_SERVICE_ACCOUNT: "not-json PRIVATE_KEY_SECRET",
 			});
 
 			mockFetch.mockResolvedValueOnce(
@@ -187,7 +199,8 @@ describe("health check", () => {
 				(c: CheckResult) => c.name === "google_sa",
 			);
 			expect(saCheck?.ok).toBe(false);
-			expect(saCheck?.error).toBeDefined();
+			expect(saCheck?.error).toBe("Invalid service account JSON format");
+			expect(saCheck?.error).not.toContain("PRIVATE_KEY_SECRET");
 		});
 
 		it("reports failure when required fields are missing", async () => {
@@ -283,8 +296,8 @@ describe("health check", () => {
 			mockFetch.mockResolvedValueOnce(
 				new Response(JSON.stringify({ models: [] }), { status: 200 }),
 			);
-			// GitHub isDuplicate - fails
-			mockFetch.mockRejectedValueOnce(new Error("Network error"));
+			// GitHub isDuplicate - permanent failure
+			mockFetch.mockResolvedValueOnce(new Response(null, { status: 403 }));
 
 			const result = await runHealthCheck(env, log);
 

--- a/src/health.ts
+++ b/src/health.ts
@@ -10,7 +10,12 @@ import {
 import { loadConfig } from "./config";
 import type { Bindings } from "./contracts";
 import { createDeduplicationStore } from "./repositories/deduplicationStore";
-import { getErrorMessage } from "./utils/errors";
+import {
+	externalServiceErrorFromResponse,
+	getErrorMessage,
+	getExternalErrorLogContext,
+	normalizeExternalServiceError,
+} from "./utils/errors";
 import type { Logger } from "./utils/logger";
 
 type CheckName = "kv" | "gemini" | "google_sa";
@@ -49,22 +54,29 @@ async function checkKV(kv: KVNamespace): Promise<CheckResult> {
 async function checkGemini(apiKey: string): Promise<CheckResult> {
 	const start = Date.now();
 	try {
-		const res = await fetch(`${GEMINI_MODELS_URL}?key=${apiKey}`);
-		if (res.ok) {
-			return { name: "gemini", ok: true, durationMs: Date.now() - start };
+		const res = await fetch(GEMINI_MODELS_URL, {
+			headers: { "x-goog-api-key": apiKey },
+		});
+		if (!res.ok) {
+			throw externalServiceErrorFromResponse(
+				"gemini",
+				"health check",
+				res,
+				"Gemini APIのヘルスチェックに失敗しました。",
+			);
 		}
-		return {
-			name: "gemini",
-			ok: false,
-			durationMs: Date.now() - start,
-			error: `HTTP ${res.status}`,
-		};
+		return { name: "gemini", ok: true, durationMs: Date.now() - start };
 	} catch (error) {
+		const normalized = normalizeExternalServiceError(error, {
+			service: "gemini",
+			operation: "health check",
+			userMessage: "Gemini APIのヘルスチェックに失敗しました。",
+		});
 		return {
 			name: "gemini",
 			ok: false,
 			durationMs: Date.now() - start,
-			error: getErrorMessage(error),
+			error: normalized.message,
 		};
 	}
 }
@@ -82,12 +94,12 @@ function checkGoogleSA(saJson: string): CheckResult {
 			};
 		}
 		return { name: "google_sa", ok: true, durationMs: Date.now() - start };
-	} catch (error) {
+	} catch {
 		return {
 			name: "google_sa",
 			ok: false,
 			durationMs: Date.now() - start,
-			error: getErrorMessage(error),
+			error: "Invalid service account JSON format",
 		};
 	}
 }
@@ -149,14 +161,12 @@ async function reportHealthCheckToGitHub(
 			timestamp: new Date().toISOString(),
 		};
 
-		const created = await github.createHealthCheckIssue(report, fingerprint);
-		if (created) {
-			await deduplicationStore.mark(kvKey, ERROR_REPORTED_TTL_SECONDS);
-			log.info("Health check reported to GitHub Issues", { fingerprint });
-		}
+		await github.createHealthCheckIssue(report, fingerprint);
+		await deduplicationStore.mark(kvKey, ERROR_REPORTED_TTL_SECONDS);
+		log.info("Health check reported to GitHub Issues", { fingerprint });
 	} catch (error) {
 		log.warn("Failed to report health check to GitHub (non-fatal)", {
-			error: getErrorMessage(error),
+			...getExternalErrorLogContext(error),
 		});
 	}
 }

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+	ExternalServiceError,
+	externalServiceErrorFromResponse,
+	getExternalErrorLogContext,
+	getUserMessage,
+	isRetryableStatus,
+	normalizeExternalServiceError,
+	parseRetryAfterMs,
+} from "./errors";
+
+describe("ExternalServiceError", () => {
+	it.each([undefined, 408, 429, 500, 503])(
+		"classifies status %s as retryable",
+		(status) => {
+			expect(isRetryableStatus(status)).toBe(true);
+		},
+	);
+
+	it.each([400, 401, 403, 404, 422])(
+		"classifies permanent status %s as non-retryable",
+		(status) => {
+			expect(isRetryableStatus(status)).toBe(false);
+		},
+	);
+
+	it("normalizes SDK errors from structured status without exposing the cause", () => {
+		const secretBody = new Error(
+			'{"error":{"message":"secret response body"}}',
+		) as Error & { status: number };
+		secretBody.status = 429;
+
+		const result = normalizeExternalServiceError(secretBody, {
+			service: "gemini",
+			operation: "generate content",
+			userMessage: "AIへの接続に失敗しました。",
+		});
+
+		expect(result).toBeInstanceOf(ExternalServiceError);
+		expect(result.status).toBe(429);
+		expect(result.retryable).toBe(true);
+		expect(result.message).toBe("gemini generate content failed (status 429)");
+		expect(result.message).not.toContain("secret response body");
+		expect(result.cause).toBe(secretBody);
+	});
+
+	it("creates a safe error from an HTTP response without reading its body", () => {
+		const response = new Response("secret response body", {
+			status: 403,
+			headers: { "Retry-After": "5" },
+		});
+
+		const result = externalServiceErrorFromResponse(
+			"github",
+			"create issue",
+			response,
+			"Issueの作成に失敗しました。",
+		);
+
+		expect(result.status).toBe(403);
+		expect(result.retryable).toBe(false);
+		expect(result.retryAfterMs).toBe(5000);
+		expect(result.message).not.toContain("secret response body");
+		expect(getUserMessage(result)).toBe("Issueの作成に失敗しました。");
+	});
+
+	it("returns only safe structured fields for logging", () => {
+		const error = new ExternalServiceError({
+			service: "discord",
+			operation: "edit message",
+			status: 500,
+			retryable: true,
+			userMessage: "Discordへの送信に失敗しました。",
+			retryAfterMs: 2000,
+			cause: new Error("secret cause"),
+		});
+
+		expect(getExternalErrorLogContext(error)).toEqual({
+			service: "discord",
+			operation: "edit message",
+			status: 500,
+			retryable: true,
+			retryAfterMs: 2000,
+		});
+	});
+});
+
+describe("parseRetryAfterMs", () => {
+	it("parses delta seconds", () => {
+		expect(parseRetryAfterMs("1.5")).toBe(1500);
+	});
+
+	it("parses an HTTP date", () => {
+		const now = Date.parse("2026-07-28T12:00:00.000Z");
+		expect(parseRetryAfterMs("Tue, 28 Jul 2026 12:00:05 GMT", now)).toBe(5000);
+	});
+
+	it("clamps excessive values and rejects invalid values", () => {
+		expect(parseRetryAfterMs("120")).toBe(60_000);
+		expect(parseRetryAfterMs("-1")).toBeUndefined();
+		expect(parseRetryAfterMs("not-a-date")).toBeUndefined();
+		expect(parseRetryAfterMs(null)).toBeUndefined();
+	});
+});

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,3 +1,163 @@
+export type ExternalService = "discord" | "gemini" | "sheets" | "github";
+
+type ExternalServiceErrorOptions = {
+	service: ExternalService;
+	operation: string;
+	status?: number;
+	retryable: boolean;
+	userMessage: string;
+	retryAfterMs?: number;
+	cause?: unknown;
+};
+
+type NormalizeExternalServiceErrorOptions = Omit<
+	ExternalServiceErrorOptions,
+	"retryable" | "status"
+> & {
+	status?: number;
+	retryable?: boolean;
+};
+
+const MAX_RETRY_AFTER_MS = 60_000;
+
+export class ExternalServiceError extends Error {
+	readonly service: ExternalService;
+	readonly operation: string;
+	readonly status?: number;
+	readonly retryable: boolean;
+	readonly userMessage: string;
+	readonly retryAfterMs?: number;
+
+	constructor(options: ExternalServiceErrorOptions) {
+		const statusSuffix =
+			options.status === undefined ? "" : ` (status ${options.status})`;
+		super(`${options.service} ${options.operation} failed${statusSuffix}`, {
+			cause: options.cause,
+		});
+		this.name = "ExternalServiceError";
+		this.service = options.service;
+		this.operation = options.operation;
+		this.status = options.status;
+		this.retryable = options.retryable;
+		this.userMessage = options.userMessage;
+		this.retryAfterMs = options.retryAfterMs;
+	}
+}
+
 export function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : "Unknown error";
+}
+
+export function getUserMessage(
+	error: unknown,
+	fallback = "予期しないエラーが発生しました。",
+): string {
+	return error instanceof ExternalServiceError ? error.userMessage : fallback;
+}
+
+export function isRetryableStatus(status: number | undefined): boolean {
+	return (
+		status === undefined ||
+		status === 408 ||
+		status === 429 ||
+		(status >= 500 && status <= 599)
+	);
+}
+
+export function parseRetryAfterMs(
+	value: string | null,
+	nowMs = Date.now(),
+	maxMs = MAX_RETRY_AFTER_MS,
+): number | undefined {
+	if (value === null) {
+		return undefined;
+	}
+
+	const trimmed = value.trim();
+	if (!trimmed) {
+		return undefined;
+	}
+
+	const seconds = Number(trimmed);
+	if (Number.isFinite(seconds)) {
+		return seconds >= 0
+			? Math.min(Math.round(seconds * 1000), maxMs)
+			: undefined;
+	}
+
+	const retryAt = Date.parse(trimmed);
+	if (Number.isNaN(retryAt)) {
+		return undefined;
+	}
+
+	return Math.min(Math.max(0, retryAt - nowMs), maxMs);
+}
+
+function extractStatus(error: unknown): number | undefined {
+	if (!error || typeof error !== "object") {
+		return undefined;
+	}
+
+	for (const field of ["status", "statusCode", "code"] as const) {
+		const value = (error as Record<string, unknown>)[field];
+		if (
+			typeof value === "number" &&
+			Number.isInteger(value) &&
+			value >= 100 &&
+			value <= 599
+		) {
+			return value;
+		}
+	}
+
+	return undefined;
+}
+
+export function normalizeExternalServiceError(
+	error: unknown,
+	options: NormalizeExternalServiceErrorOptions,
+): ExternalServiceError {
+	if (error instanceof ExternalServiceError) {
+		return error;
+	}
+
+	const status = options.status ?? extractStatus(error);
+	return new ExternalServiceError({
+		...options,
+		status,
+		retryable: options.retryable ?? isRetryableStatus(status),
+		cause: error,
+	});
+}
+
+export function externalServiceErrorFromResponse(
+	service: ExternalService,
+	operation: string,
+	response: Response,
+	userMessage: string,
+): ExternalServiceError {
+	return new ExternalServiceError({
+		service,
+		operation,
+		status: response.status,
+		retryable: isRetryableStatus(response.status),
+		userMessage,
+		retryAfterMs: parseRetryAfterMs(response.headers.get("Retry-After")),
+	});
+}
+
+export function getExternalErrorLogContext(
+	error: unknown,
+): Record<string, unknown> {
+	if (!(error instanceof ExternalServiceError)) {
+		return { error: getErrorMessage(error) };
+	}
+
+	return {
+		service: error.service,
+		operation: error.operation,
+		status: error.status,
+		retryable: error.retryable,
+		retryAfterMs: error.retryAfterMs,
+	};
 }

--- a/src/utils/retry.test.ts
+++ b/src/utils/retry.test.ts
@@ -1,264 +1,176 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { ExternalServiceError } from "./errors";
 import { withRetry } from "./retry";
 
+function serviceError(
+	status: number | undefined,
+	options: { retryable?: boolean; retryAfterMs?: number } = {},
+) {
+	return new ExternalServiceError({
+		service: "discord",
+		operation: "post message",
+		status,
+		retryable: options.retryable ?? true,
+		userMessage: "Discordへの送信に失敗しました。",
+		retryAfterMs: options.retryAfterMs,
+	});
+}
+
 describe("withRetry", () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
-		vi.useFakeTimers();
+	it("returns a successful result without sleeping", async () => {
+		const fn = vi.fn().mockResolvedValue("success");
+		const sleep = vi.fn();
+
+		await expect(withRetry(fn, { sleep })).resolves.toBe("success");
+		expect(fn).toHaveBeenCalledTimes(1);
+		expect(sleep).not.toHaveBeenCalled();
 	});
 
-	afterEach(() => {
-		vi.useRealTimers();
+	it.each([undefined, 408, 429, 500, 503])(
+		"retries a retryable status %s",
+		async (status) => {
+			const fn = vi
+				.fn()
+				.mockRejectedValueOnce(serviceError(status))
+				.mockResolvedValueOnce("success");
+			const sleep = vi.fn().mockResolvedValue(undefined);
+
+			await expect(withRetry(fn, { sleep, random: () => 0.5 })).resolves.toBe(
+				"success",
+			);
+			expect(fn).toHaveBeenCalledTimes(2);
+			expect(sleep).toHaveBeenCalledTimes(1);
+		},
+	);
+
+	it.each([400, 401, 403, 404])(
+		"does not retry a permanent status %s",
+		async (status) => {
+			const error = serviceError(status, { retryable: false });
+			const fn = vi.fn().mockRejectedValue(error);
+			const sleep = vi.fn();
+
+			await expect(withRetry(fn, { sleep })).rejects.toBe(error);
+			expect(fn).toHaveBeenCalledTimes(1);
+			expect(sleep).not.toHaveBeenCalled();
+		},
+	);
+
+	it("does not retry generic errors by default", async () => {
+		const fn = vi.fn().mockRejectedValue(new Error("local failure"));
+
+		await expect(withRetry(fn, { sleep: vi.fn() })).rejects.toThrow(
+			"local failure",
+		);
+		expect(fn).toHaveBeenCalledTimes(1);
 	});
 
-	describe("successful execution", () => {
-		it("returns result on first attempt", async () => {
-			const mockFn = vi.fn().mockResolvedValue("success");
+	it("uses Retry-After instead of exponential backoff", async () => {
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(serviceError(429, { retryAfterMs: 4200 }))
+			.mockResolvedValueOnce("success");
+		const sleep = vi.fn().mockResolvedValue(undefined);
 
-			const promise = withRetry(mockFn);
-			await vi.runAllTimersAsync();
-			const result = await promise;
-
-			expect(result).toBe("success");
-			expect(mockFn).toHaveBeenCalledTimes(1);
+		await withRetry(fn, {
+			initialDelayMs: 1000,
+			sleep,
+			random: () => 0.25,
 		});
 
-		it("returns result after retry", async () => {
-			const mockFn = vi
-				.fn()
-				.mockRejectedValueOnce(new Error("temporary error"))
-				.mockResolvedValueOnce("success");
-
-			const promise = withRetry(mockFn);
-			await vi.runAllTimersAsync();
-			const result = await promise;
-
-			expect(result).toBe("success");
-			expect(mockFn).toHaveBeenCalledTimes(2);
-		});
+		expect(sleep).toHaveBeenCalledWith(4200);
 	});
 
-	describe("retry behavior", () => {
-		it("retries up to maxAttempts times", async () => {
-			const mockFn = vi.fn().mockRejectedValue(new Error("persistent error"));
+	it("uses capped exponential backoff with full jitter", async () => {
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(serviceError(500))
+			.mockRejectedValueOnce(serviceError(503))
+			.mockRejectedValueOnce(serviceError(408))
+			.mockResolvedValueOnce("success");
+		const sleep = vi.fn().mockResolvedValue(undefined);
+		const random = vi
+			.fn()
+			.mockReturnValueOnce(0.5)
+			.mockReturnValueOnce(0.25)
+			.mockReturnValueOnce(1);
 
-			// runAllTimersAsync() の実行中に reject するため、先に assertion を
-			// 繋いでハンドラを登録しておく (vitest 4 は未処理の rejection を
-			// Unhandled Error として検出し、テストが通っても exit code 1 になる)
-			const promise = withRetry(mockFn, { maxAttempts: 3 });
-			const assertion = expect(promise).rejects.toThrow("persistent error");
-			await vi.runAllTimersAsync();
-			await assertion;
-
-			expect(mockFn).toHaveBeenCalledTimes(3);
+		await withRetry(fn, {
+			maxAttempts: 4,
+			initialDelayMs: 1000,
+			backoffMultiplier: 3,
+			maxDelayMs: 5000,
+			sleep,
+			random,
 		});
 
-		it("uses exponential backoff", async () => {
-			const mockFn = vi
-				.fn()
-				.mockRejectedValueOnce(new Error("error 1"))
-				.mockRejectedValueOnce(new Error("error 2"))
-				.mockResolvedValueOnce("success");
-
-			const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-
-			const promise = withRetry(mockFn, {
-				initialDelayMs: 1000,
-				backoffMultiplier: 2,
-			});
-
-			// Fast-forward through all timers
-			await vi.runAllTimersAsync();
-			await promise;
-
-			// Verify delays: 1000ms, 2000ms (logged as JSON)
-			const calls = consoleSpy.mock.calls.map((call) => call[0]);
-			expect(calls.some((c) => c.includes('"delayMs":1000'))).toBe(true);
-			expect(calls.some((c) => c.includes('"delayMs":2000'))).toBe(true);
-
-			consoleSpy.mockRestore();
-		});
-
-		it("caps delay at maxDelayMs", async () => {
-			const mockFn = vi
-				.fn()
-				.mockRejectedValueOnce(new Error("error 1"))
-				.mockRejectedValueOnce(new Error("error 2"))
-				.mockResolvedValueOnce("success");
-
-			const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-
-			const promise = withRetry(mockFn, {
-				initialDelayMs: 5000,
-				backoffMultiplier: 3,
-				maxDelayMs: 8000,
-			});
-
-			await vi.runAllTimersAsync();
-			await promise;
-
-			// First retry: 5000ms, second retry: min(15000, 8000) = 8000ms (logged as JSON)
-			const calls = consoleSpy.mock.calls.map((call) => call[0]);
-			expect(calls.some((c) => c.includes('"delayMs":5000'))).toBe(true);
-			expect(calls.some((c) => c.includes('"delayMs":8000'))).toBe(true);
-
-			consoleSpy.mockRestore();
-		});
+		expect(sleep.mock.calls).toEqual([[500], [750], [5000]]);
 	});
 
-	describe("shouldRetry callback", () => {
-		it("stops retrying when shouldRetry returns false", async () => {
-			const mockFn = vi
-				.fn()
-				.mockRejectedValue(new Error("non-retryable error"));
+	it("throws the last error after maxAttempts", async () => {
+		const first = serviceError(500);
+		const last = serviceError(503);
+		const fn = vi.fn().mockRejectedValueOnce(first).mockRejectedValueOnce(last);
 
-			const shouldRetry = (error: Error) => {
-				return error.message !== "non-retryable error";
-			};
-
-			const promise = withRetry(mockFn, { maxAttempts: 3 }, shouldRetry);
-			const assertion = expect(promise).rejects.toThrow("non-retryable error");
-			await vi.runAllTimersAsync();
-			await assertion;
-
-			expect(mockFn).toHaveBeenCalledTimes(1);
-		});
-
-		it("continues retrying for retryable errors", async () => {
-			const mockFn = vi
-				.fn()
-				.mockRejectedValueOnce(new Error("retryable error"))
-				.mockResolvedValueOnce("success");
-
-			const shouldRetry = (error: Error) => {
-				return error.message.includes("retryable");
-			};
-
-			const promise = withRetry(mockFn, {}, shouldRetry);
-			await vi.runAllTimersAsync();
-			const result = await promise;
-
-			expect(result).toBe("success");
-			expect(mockFn).toHaveBeenCalledTimes(2);
-		});
-
-		it("classifies rate limit errors as retryable", async () => {
-			const mockFn = vi
-				.fn()
-				.mockRejectedValueOnce(new Error("rate limit exceeded"))
-				.mockResolvedValueOnce("success");
-
-			const shouldRetry = (error: Error) => {
-				const msg = error.message.toLowerCase();
-				return msg.includes("quota") || msg.includes("rate limit");
-			};
-
-			const promise = withRetry(mockFn, {}, shouldRetry);
-			await vi.runAllTimersAsync();
-			const result = await promise;
-
-			expect(result).toBe("success");
-			expect(mockFn).toHaveBeenCalledTimes(2);
-		});
-
-		it("classifies network errors as retryable", async () => {
-			const mockFn = vi
-				.fn()
-				.mockRejectedValueOnce(new Error("network timeout"))
-				.mockResolvedValueOnce("success");
-
-			const shouldRetry = (error: Error) => {
-				const msg = error.message.toLowerCase();
-				return msg.includes("network") || msg.includes("timeout");
-			};
-
-			const promise = withRetry(mockFn, {}, shouldRetry);
-			await vi.runAllTimersAsync();
-			const result = await promise;
-
-			expect(result).toBe("success");
-			expect(mockFn).toHaveBeenCalledTimes(2);
-		});
+		await expect(
+			withRetry(fn, {
+				maxAttempts: 2,
+				sleep: vi.fn().mockResolvedValue(undefined),
+				random: () => 0,
+			}),
+		).rejects.toBe(last);
+		expect(fn).toHaveBeenCalledTimes(2);
 	});
 
-	describe("error handling", () => {
-		it("throws last error after all retries exhausted", async () => {
-			const error1 = new Error("error 1");
-			const error2 = new Error("error 2");
-			const error3 = new Error("final error");
+	it("allows an explicit retry predicate for non-service operations", async () => {
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("retry me"))
+			.mockResolvedValueOnce("success");
 
-			const mockFn = vi
-				.fn()
-				.mockRejectedValueOnce(error1)
-				.mockRejectedValueOnce(error2)
-				.mockRejectedValueOnce(error3);
-
-			const promise = withRetry(mockFn, { maxAttempts: 3 });
-			const assertion = expect(promise).rejects.toThrow("final error");
-			await vi.runAllTimersAsync();
-			await assertion;
-		});
-
-		it("converts non-Error values to Error", async () => {
-			const mockFn = vi.fn().mockRejectedValue("string error");
-
-			const promise = withRetry(mockFn, { maxAttempts: 1 });
-			const assertion = expect(promise).rejects.toThrow("string error");
-			await vi.runAllTimersAsync();
-			await assertion;
-		});
+		await expect(
+			withRetry(
+				fn,
+				{ sleep: vi.fn().mockResolvedValue(undefined), random: () => 0 },
+				() => true,
+			),
+		).resolves.toBe("success");
 	});
 
-	describe("configuration", () => {
-		it("uses default configuration when not provided", async () => {
-			const mockFn = vi
-				.fn()
-				.mockRejectedValueOnce(new Error("error"))
-				.mockResolvedValueOnce("success");
-
-			const promise = withRetry(mockFn);
-			await vi.runAllTimersAsync();
-			const result = await promise;
-
-			expect(result).toBe("success");
+	it("logs structured fields without the cause message", async () => {
+		const log = {
+			warn: vi.fn(),
+		};
+		const error = new ExternalServiceError({
+			service: "gemini",
+			operation: "generate content",
+			status: 500,
+			retryable: true,
+			userMessage: "AIへの接続に失敗しました。",
+			cause: new Error("secret response body"),
 		});
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(error)
+			.mockResolvedValueOnce("success");
 
-		it("merges partial config with defaults", async () => {
-			const mockFn = vi
-				.fn()
-				.mockRejectedValueOnce(new Error("error"))
-				.mockResolvedValueOnce("success");
+		await withRetry(
+			fn,
+			{ sleep: vi.fn().mockResolvedValue(undefined), random: () => 0 },
+			undefined,
+			log as never,
+		);
 
-			const promise = withRetry(mockFn, { maxAttempts: 2 });
-			await vi.runAllTimersAsync();
-			const result = await promise;
-
-			expect(result).toBe("success");
-		});
-	});
-
-	describe("logging", () => {
-		it("logs retry attempts", async () => {
-			const mockFn = vi
-				.fn()
-				.mockRejectedValueOnce(new Error("temporary error"))
-				.mockResolvedValueOnce("success");
-
-			const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-
-			const promise = withRetry(mockFn);
-			await vi.runAllTimersAsync();
-			await promise;
-
-			// Logs are now JSON formatted
-			const calls = consoleSpy.mock.calls.map((call) => call[0]);
-			expect(
-				calls.some(
-					(c) => c.includes("Retry attempt") && c.includes("temporary error"),
-				),
-			).toBe(true);
-
-			consoleSpy.mockRestore();
-		});
+		expect(log.warn).toHaveBeenCalledWith(
+			"Retrying external service request",
+			expect.objectContaining({
+				service: "gemini",
+				operation: "generate content",
+				status: 500,
+			}),
+		);
+		expect(JSON.stringify(log.warn.mock.calls)).not.toContain(
+			"secret response body",
+		);
 	});
 });

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,27 +1,49 @@
+import { ExternalServiceError, getExternalErrorLogContext } from "./errors";
 import { logger as defaultLogger, type Logger } from "./logger";
+
+type Sleep = (delayMs: number) => Promise<void>;
+type RandomSource = () => number;
 
 export interface RetryConfig {
 	maxAttempts: number;
 	initialDelayMs: number;
 	maxDelayMs: number;
 	backoffMultiplier: number;
+	sleep: Sleep;
+	random: RandomSource;
 }
+
+const defaultSleep: Sleep = async (delayMs) => {
+	await new Promise((resolve) => setTimeout(resolve, delayMs));
+};
 
 const DEFAULT_RETRY_CONFIG: RetryConfig = {
 	maxAttempts: 3,
 	initialDelayMs: 1000,
 	maxDelayMs: 10000,
 	backoffMultiplier: 2,
+	sleep: defaultSleep,
+	random: Math.random,
 };
+
+const isRetryableExternalServiceError = (error: Error): boolean =>
+	error instanceof ExternalServiceError && error.retryable;
 
 export async function withRetry<T>(
 	fn: () => Promise<T>,
 	config: Partial<RetryConfig> = {},
-	shouldRetry: (error: Error) => boolean = () => true,
+	shouldRetry: (error: Error) => boolean = isRetryableExternalServiceError,
 	log?: Logger,
 ): Promise<T> {
 	const logger = log ?? defaultLogger;
-	const { maxAttempts, initialDelayMs, maxDelayMs, backoffMultiplier } = {
+	const {
+		maxAttempts,
+		initialDelayMs,
+		maxDelayMs,
+		backoffMultiplier,
+		sleep,
+		random,
+	} = {
 		...DEFAULT_RETRY_CONFIG,
 		...config,
 	};
@@ -39,18 +61,25 @@ export async function withRetry<T>(
 				throw lastError;
 			}
 
-			// Calculate delay with exponential backoff
-			const delay = Math.min(
+			const cappedBackoff = Math.min(
 				initialDelayMs * backoffMultiplier ** attempt,
 				maxDelayMs,
 			);
+			const randomValue = Math.min(1, Math.max(0, random()));
+			const delay =
+				lastError instanceof ExternalServiceError &&
+				lastError.retryAfterMs !== undefined
+					? lastError.retryAfterMs
+					: Math.round(cappedBackoff * randomValue);
 
-			logger.warn(`Retry attempt ${attempt + 1}/${maxAttempts}`, {
+			logger.warn("Retrying external service request", {
+				attempt: attempt + 1,
+				maxAttempts,
 				delayMs: delay,
-				error: lastError.message,
+				...getExternalErrorLogContext(lastError),
 			});
 
-			await new Promise((resolve) => setTimeout(resolve, delay));
+			await sleep(delay);
 		}
 	}
 

--- a/src/workflows/answerQuestionWorkflow.test.ts
+++ b/src/workflows/answerQuestionWorkflow.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Bindings, HistoryEntry } from "../contracts";
+import { ExternalServiceError } from "../utils/errors";
 import type { Logger } from "../utils/logger";
 import type { HistoryOutput, SheetDataOutput } from "./types";
 
@@ -130,6 +131,10 @@ describe("AnswerQuestionWorkflow Steps", () => {
 		mockDeduplicationStore.isMarked.mockResolvedValue(false);
 		// Reset fetch mock
 		globalThis.fetch = vi.fn();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
 	describe("getSheetDataStep", () => {
@@ -491,7 +496,17 @@ describe("AnswerQuestionWorkflow Steps", () => {
 			);
 			mockGeminiInstance.getHistory.mockReturnValue([]);
 			// Intermediate edits may fail, but final edit succeeds
-			mockDiscordInstance.editOriginalMessage.mockResolvedValue(true);
+			mockDiscordInstance.editOriginalMessage
+				.mockRejectedValueOnce(
+					new ExternalServiceError({
+						service: "discord",
+						operation: "edit original message",
+						status: 400,
+						retryable: false,
+						userMessage: "Discordへの応答送信に失敗しました。",
+					}),
+				)
+				.mockResolvedValueOnce(undefined);
 
 			const result = await streamGeminiWithDiscordEditsStep(
 				mockEnv,
@@ -504,6 +519,7 @@ describe("AnswerQuestionWorkflow Steps", () => {
 			);
 
 			expect(result.response).toBe("response text");
+			expect(mockDiscordInstance.editOriginalMessage).toHaveBeenCalledTimes(2);
 		});
 
 		it("passes existing history to GeminiClient", async () => {
@@ -659,6 +675,19 @@ describe("AnswerQuestionWorkflow Steps", () => {
 	});
 
 	describe("sendDiscordResponseStep", () => {
+		const discordError = (
+			status: number,
+			options: { retryable: boolean; retryAfterMs?: number },
+		) =>
+			new ExternalServiceError({
+				service: "discord",
+				operation: "post message",
+				status,
+				retryable: options.retryable,
+				userMessage: "Discordへのメッセージ送信に失敗しました。",
+				retryAfterMs: options.retryAfterMs,
+			});
+
 		it("sends successful response to Discord webhook", async () => {
 			mockDiscordInstance.postMessage.mockResolvedValue(true);
 
@@ -695,34 +724,40 @@ describe("AnswerQuestionWorkflow Steps", () => {
 		});
 
 		it("retries on failure", async () => {
+			vi.useFakeTimers();
 			mockDiscordInstance.postMessage
-				.mockRejectedValueOnce(new Error("Discord POST failed with status 500"))
-				.mockResolvedValueOnce(true);
+				.mockRejectedValueOnce(discordError(500, { retryable: true }))
+				.mockResolvedValueOnce(undefined);
 
-			const result = await sendDiscordResponseStep(
+			const promise = sendDiscordResponseStep(
 				mockEnv,
 				"token",
 				"question",
 				"answer",
 				mockLogger,
 			);
+			await vi.runAllTimersAsync();
+			const result = await promise;
 
 			expect(mockDiscordInstance.postMessage).toHaveBeenCalledTimes(2);
 			expect(result).toEqual({ success: true, statusCode: 200, retryCount: 1 });
 		});
 
 		it("returns failure after all retries exhausted", async () => {
+			vi.useFakeTimers();
 			mockDiscordInstance.postMessage.mockRejectedValue(
-				new Error("Discord POST failed with status 500"),
+				discordError(500, { retryable: true }),
 			);
 
-			const result = await sendDiscordResponseStep(
+			const promise = sendDiscordResponseStep(
 				mockEnv,
 				"token",
 				"question",
 				"answer",
 				mockLogger,
 			);
+			await vi.runAllTimersAsync();
+			const result = await promise;
 
 			expect(mockDiscordInstance.postMessage).toHaveBeenCalledTimes(3); // Initial + 2 retries
 			expect(result).toEqual({
@@ -730,6 +765,58 @@ describe("AnswerQuestionWorkflow Steps", () => {
 				statusCode: 500,
 				retryCount: 2,
 			});
+		});
+
+		it.each([400, 401, 403, 404])(
+			"does not retry permanent status %s",
+			async (status) => {
+				mockDiscordInstance.postMessage.mockRejectedValue(
+					discordError(status, { retryable: false }),
+				);
+
+				const result = await sendDiscordResponseStep(
+					mockEnv,
+					"token",
+					"question",
+					"answer",
+					mockLogger,
+				);
+
+				expect(mockDiscordInstance.postMessage).toHaveBeenCalledTimes(1);
+				expect(result).toEqual({
+					success: false,
+					statusCode: status,
+					retryCount: 0,
+				});
+			},
+		);
+
+		it("uses Retry-After for status 429", async () => {
+			vi.useFakeTimers();
+			mockDiscordInstance.postMessage
+				.mockRejectedValueOnce(
+					discordError(429, { retryable: true, retryAfterMs: 2500 }),
+				)
+				.mockResolvedValueOnce(undefined);
+
+			const promise = sendDiscordResponseStep(
+				mockEnv,
+				"token",
+				"question",
+				"answer",
+				mockLogger,
+			);
+			await vi.runAllTimersAsync();
+
+			await expect(promise).resolves.toEqual({
+				success: true,
+				statusCode: 200,
+				retryCount: 1,
+			});
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				"Retrying external service request",
+				expect.objectContaining({ delayMs: 2500, status: 429 }),
+			);
 		});
 	});
 });

--- a/src/workflows/answerQuestionWorkflow.ts
+++ b/src/workflows/answerQuestionWorkflow.ts
@@ -18,7 +18,13 @@ import type { Bindings, HistoryEntry } from "../contracts";
 import { createConversationHistoryRepository } from "../repositories/conversationHistory";
 import { createDeduplicationStore } from "../repositories/deduplicationStore";
 import { createSheetCacheRepository } from "../repositories/sheetCache";
-import { getErrorMessage } from "../utils/errors";
+import {
+	ExternalServiceError,
+	getErrorMessage,
+	getExternalErrorLogContext,
+	getUserMessage,
+	normalizeExternalServiceError,
+} from "../utils/errors";
 import { type Logger, logger } from "../utils/logger";
 import { withRetry } from "../utils/retry";
 import type {
@@ -143,6 +149,12 @@ const THINKING_EDIT_INTERVAL_MS = 1000;
 const THINKING_MIN_CHUNK_SIZE = 200;
 
 const THINKING_FALLBACK = "考え中...";
+const DISCORD_RETRY_CONFIG = {
+	maxAttempts: 3,
+	initialDelayMs: 1000,
+	maxDelayMs: 10_000,
+	backoffMultiplier: 2,
+};
 
 export async function summarizeThinking(
 	client: GoogleGenAI,
@@ -168,8 +180,13 @@ export async function summarizeThinking(
 		log.warn("Empty summarization result, using fallback");
 		return THINKING_FALLBACK;
 	} catch (error) {
+		const normalized = normalizeExternalServiceError(error, {
+			service: "gemini",
+			operation: "summarize thinking",
+			userMessage: "思考要約の生成に失敗しました。",
+		});
 		log.warn("Thinking summarization failed (non-fatal)", {
-			error: getErrorMessage(error),
+			...getExternalErrorLogContext(normalized),
 		});
 		return THINKING_FALLBACK;
 	}
@@ -261,8 +278,13 @@ export async function streamGeminiWithDiscordEditsStep(
 						)
 					: formatContent(accumulatedText);
 
-			const success = await discord.editOriginalMessage(content);
-			if (success) {
+			try {
+				await withRetry(
+					async () => await discord.editOriginalMessage(content),
+					DISCORD_RETRY_CONFIG,
+					undefined,
+					log,
+				);
 				lastEditTime = now;
 				if (phase === "thinking") {
 					lastThinkingEditLength = accumulatedThinking.length;
@@ -274,6 +296,10 @@ export async function streamGeminiWithDiscordEditsStep(
 					editCount,
 					phase,
 					contentLength: textLength,
+				});
+			} catch (error) {
+				log.warn("Intermediate Discord edit failed (non-fatal)", {
+					...getExternalErrorLogContext(error),
 				});
 			}
 		}
@@ -288,7 +314,12 @@ export async function streamGeminiWithDiscordEditsStep(
 	);
 
 	// Final edit to ensure complete response is shown (response only, no thinking)
-	await discord.editOriginalMessage(formatContent(response));
+	await withRetry(
+		async () => await discord.editOriginalMessage(formatContent(response)),
+		DISCORD_RETRY_CONFIG,
+		undefined,
+		log,
+	);
 	editCount++;
 	log.info("Final Discord edit sent", {
 		editCount,
@@ -337,7 +368,7 @@ export async function sendDiscordResponseStep(
 				initialDelayMs: 1000,
 				backoffMultiplier: 2,
 			},
-			() => true, // Retry all errors
+			undefined,
 			log,
 		);
 
@@ -347,11 +378,8 @@ export async function sendDiscordResponseStep(
 			retryCount: attemptCount - 1, // retryCount = attempts - 1
 		};
 	} catch (error) {
-		// Extract status code from error message if available
-		const errorMsg = getErrorMessage(error);
-		const match = errorMsg.match(/status (\d+)/);
-		if (match) {
-			statusCode = Number.parseInt(match[1], 10);
+		if (error instanceof ExternalServiceError) {
+			statusCode = error.status;
 		}
 
 		return {
@@ -408,14 +436,12 @@ export async function reportErrorToGitHub(
 		}
 
 		// Create the issue
-		const created = await github.createIssue(report, fingerprint);
-		if (created) {
-			await deduplicationStore.mark(kvKey, ERROR_REPORTED_TTL_SECONDS);
-			log.info("Error reported to GitHub Issues", { fingerprint });
-		}
+		await github.createIssue(report, fingerprint);
+		await deduplicationStore.mark(kvKey, ERROR_REPORTED_TTL_SECONDS);
+		log.info("Error reported to GitHub Issues", { fingerprint });
 	} catch (error) {
 		log.warn("Failed to report error to GitHub (non-fatal)", {
-			error: getErrorMessage(error),
+			...getExternalErrorLogContext(error),
 		});
 	}
 }
@@ -486,7 +512,7 @@ export class AnswerQuestionWorkflow extends WorkflowEntrypoint<
 					"streamGeminiAndEditDiscord",
 					{
 						retries: {
-							limit: 2,
+							limit: 0,
 							delay: "1 second",
 							backoff: "exponential",
 						},
@@ -541,9 +567,10 @@ export class AnswerQuestionWorkflow extends WorkflowEntrypoint<
 		} catch (error) {
 			// Send error response to Discord
 			const errorMessage = getErrorMessage(error);
+			const userMessage = getUserMessage(error);
 			const failureDurationMs = Date.now() - workflowStartTime;
 			log.error("Workflow error", {
-				error: errorMessage,
+				...getExternalErrorLogContext(error),
 				durationMs: failureDurationMs,
 			});
 
@@ -581,7 +608,7 @@ export class AnswerQuestionWorkflow extends WorkflowEntrypoint<
 						message,
 						null,
 						log.withContext({ step: "sendErrorResponse" }),
-						errorMessage,
+						userMessage,
 					);
 				},
 			);


### PR DESCRIPTION
## 対象 Issue

- #363
- Parent: #358

## 変更内容

- `ExternalServiceError` に service / operation / status / retryable / userMessage / retryAfterMs / cause を集約
- retry対象をnetwork error、408、429、5xxに限定し、恒久4xxは即時停止
- Retry-After（秒数・HTTP-date）を優先し、それ以外は上限付き指数backoff＋full jitterを使用
- retry helperへsleepとrandom sourceを注入可能にして、実時間に依存しないテストへ変更
- Discord、Gemini、Google Sheets、GitHubの失敗をtyped errorへ正規化
- SDKのresponse bodyやsecretをerror message・retry logへ出さない構造へ変更
- Gemini health checkのAPI keyをURL queryから `x-goog-api-key` headerへ移動
- Workflowの利用者向け文言と内部errorを分離し、statusの文字列復元を廃止
- Gemini＋Discord streaming stepのWorkflow-level retryを無効化し、完了済みDiscord編集の無条件再実行を防止

## 責務の変更前後

変更前はclientごとにboolean、generic Error、message文字列検索が混在し、retry判断・利用者表示・ログが同じerror messageへ依存していました。変更後は各clientが外部障害を `ExternalServiceError` へ正規化し、共通retry helperが構造化されたretryable/status/Retry-Afterだけを参照します。Workflowはtyped errorから利用者向け文言と内部報告を別々に扱います。

## 互換性・判断事項

- `/ask`、Discord PING、署名検証、3秒以内の遅延応答は変更していません
- Discordの途中編集はretry後も失敗した場合はbest-effortで継続し、最終編集は失敗をWorkflowへ返します
- GitHub issue検索GETは共通policyでretryします
- GitHub issue作成POSTは、応答喪失時の二重作成を避けるため自動retryせず、既存のbest-effort境界で処理します
- Google Sheetsのdescription取得は従来どおりbest-effortです
- 新しい永続ストレージやQueueは追加していません

## 検証

- `npm run verify`
  - Biome check成功
  - TypeScript typecheck成功
  - Vitest: 19 files / 257 tests成功
  - Wrangler deploy dry-run成功
- 追加・更新テスト: network / 408 / 429 / 500 / 503、恒久400 / 401 / 403 / 404、Retry-After、full jitter、最大delay、sleep/random注入、各clientのtyped error、secret/response body非露出、health check API key header送信
- `InteractionType.PING` handlerは差分なし

## ロールバック

このPRをrevertします。永続データ形式・binding・環境変数は変更していないため、データmigrationは不要です。

> Issueはマージだけでは閉じず、CIと必要な実環境確認後に完了扱いとします。