### PR TITLE
docs: sync CLAUDE.md after PR #379

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,12 +12,70 @@ npm run register     # Register Discord slash commands via Discord API
 npm run check        # Run Biome formatter + linter with auto-fix
 npm run check:ci     # Run Biome check without writing (for CI)
 npm run typecheck    # Run TypeScript type checking without emitting files
+npm run cf-typegen   # Regenerate Cloudflare binding types (worker-configuration.d.ts)
 npm run verify       # Run all non-writing checks, tests, and a deploy dry-run
 ```
 
 ## Architecture
 
-Discord bot on Cloudflare Workers. Uses Google Gemini AI with a Google Sheets knowledge base. Cron health check (every 5 min) reports failures as GitHub Issues.
+Discord bot on Cloudflare Workers. Uses Google Gemini AI with a Google Sheets knowledge base, Cloudflare KV for caches and conversation history, Analytics Engine for metrics, and a Cloudflare Workflow for answer generation. Cron health check (every 5 min) reports failures as GitHub Issues.
+
+Tests run under `@cloudflare/vitest-pool-workers` against `wrangler.toml`, so they execute in the real Workers runtime.
+
+### Request flow
+
+1. Discord POSTs to `/`; the `verifyDiscordInteraction` middleware verifies the Ed25519 signature.
+2. `InteractionType.PING` returns PONG. `APPLICATION_COMMAND` calls `loadConfig` to fail fast at the request boundary, parses the `/ask` command, creates an `ANSWER_QUESTION_WORKFLOW` instance, and immediately returns `DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE` — Discord requires a response within 3 seconds, so the real work runs in the Workflow.
+3. `AnswerQuestionWorkflow` (`src/workflows/answerQuestionWorkflow.ts`) runs asynchronously:
+   - `getSheetData` — read the KV sheet cache, falling back to Google Sheets and writing the cache back (best effort).
+   - `getHistory` — load conversation history from KV.
+   - `streamGeminiAndEditDiscord` — stream the Gemini response while progressively PATCHing the Discord message. Configured with `retries.limit: 0` and a 120 second timeout, because retrying would re-send partial output.
+   - `saveHistory` — write the updated history back to KV.
+   - On failure: log, record metrics, report to GitHub Issues (called *outside* `step.do` so the Workflow does not retry the report), then send an error message via `sendErrorResponse`.
+4. Metrics for each stage are written to Analytics Engine; when the `METRICS` binding is absent, `NoOpMetricsClient` is used.
+
+`AnswerQuestionWorkflow` is re-exported from `src/index.ts` so Cloudflare can discover the Workflow class. Do not remove that re-export.
+
+### Caching
+
+All caches live in the single KV namespace bound as `sushanshan_bot`:
+
+- `sheet_info:v2:<sha256(spreadsheet id + sheet names)>` — sheet data and description, TTL 5 minutes. Keying by source fingerprint means changing `GOOGLE_SPREADSHEET_ID` or the sheet names automatically misses the old cache (`src/repositories/sheetCache.ts`).
+- `chat_history:v2:<conversationKey>` — conversation history, where `conversationKey` is `sha256(guildId|"dm":channelId:userId)`. Capped at the last 20 entries and 64 KB, TTL `HISTORY_TTL_SECONDS` (`src/repositories/conversationHistory.ts`).
+- `error_reported:<fingerprint>` — marker preventing duplicate GitHub Issues, TTL 1 hour. This is layer 1 of deduplication; layer 2 is a GitHub Issues search (`src/repositories/deduplicationStore.ts`).
+
+Cache and history reads degrade gracefully: KV failures are logged and treated as a miss rather than failing the request.
+
+### External service errors and retries
+
+Unified across all clients (`src/utils/errors.ts`, `src/utils/retry.ts`):
+
+- Wrap external failures in `ExternalServiceError` via `normalizeExternalServiceError` or `externalServiceErrorFromResponse`. It carries `service` (`discord` | `gemini` | `sheets` | `github`), `operation`, `status`, `retryable`, `userMessage` (Japanese, shown to the user), and `retryAfterMs` parsed from the `Retry-After` header.
+- `withRetry` retries only retryable `ExternalServiceError`s by default. It uses jittered exponential backoff, honors `retryAfterMs` when present, and accepts injectable `sleep`/`random` so tests do not wait on real timers.
+- `isRetryableStatus` treats 408, 429, 5xx, and unknown status as retryable.
+- Log failures with `getExternalErrorLogContext`, and derive user-facing text with `getUserMessage`.
+
+## Project Structure
+
+```
+src/
+  index.ts                    # Hono app, Discord interaction endpoint, cron entrypoint, Workflow re-export
+  config.ts                   # Bindings → AppConfig loading, validation, production defaults
+  contracts.ts                # Dependency-free shared types, including the Bindings type
+  health.ts                   # Cron health check (KV, Gemini, Google service account)
+  clients/                    # External service clients: discord, gemini, github, spreadSheet, metrics
+  discord/interaction.ts      # Interaction parsing, /ask validation, conversation key derivation
+  middleware/                 # verifyDiscordInteraction (Ed25519 signature verification)
+  repositories/               # KV access by purpose: sheetCache, conversationHistory, deduplicationStore
+  responses/errorResponse.ts  # Discord error message payload
+  utils/                      # errors, retry, logger, requestId, compactSheet
+  workflows/                  # AnswerQuestionWorkflow and its step output types
+scripts/
+  commands.js                 # Slash command definitions shared by runtime and registration
+  register.js                 # Registers slash commands with the Discord API
+```
+
+Tests are colocated as `*.test.ts` next to the file under test.
 
 ## Environment Variables
 
@@ -34,6 +92,15 @@ Optional runtime configuration (current production values are used when omitted)
 - `GOOGLE_SPREADSHEET_ID`, `GOOGLE_DATA_SHEET_NAME`, `GOOGLE_DESCRIPTION_SHEET_NAME` - Google Sheets source
 - `GITHUB_REPOSITORY` - Error-report destination in `owner/repository` format
 - `HISTORY_TTL_SECONDS` - Conversation history TTL (60–86400 seconds, default: 300)
+
+## Cloudflare Bindings
+
+Defined in `wrangler.toml` and typed in `Bindings` (`src/contracts.ts`):
+
+- `sushanshan_bot` - KV namespace for the sheet cache, conversation history, and Issue deduplication
+- `ANSWER_QUESTION_WORKFLOW` - Workflow binding for `AnswerQuestionWorkflow`
+- `METRICS` (optional) - Analytics Engine dataset `yangbingyibot_metrics`
+- Cron trigger `*/5 * * * *` drives the health check
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary

CLAUDE.md の内容を PR #379 (refactor: 外部サービスのerrorとretry policyを統一する) のマージ後の実コードと同期します。

## Changes

### Architecture (大幅に加筆)
- **Request flow** を追記。署名検証 → PING/APPLICATION_COMMAND の分岐 → `loadConfig` による fail fast → Workflow 生成 → `DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE` 即時返却（Discord の 3 秒制約）→ `AnswerQuestionWorkflow` の 4 ステップ（`getSheetData` / `getHistory` / `streamGeminiAndEditDiscord` / `saveHistory`）とエラー時の挙動。従来は「Discord bot on Cloudflare Workers」の 1 行のみで、中核である Cloudflare Workflow への言及自体が欠けていました
- `streamGeminiAndEditDiscord` の `retries.limit: 0` / 120 秒タイムアウト、GitHub Issue 報告を `step.do` の外で行う理由を明記
- **Caching** を追記。KV ネームスペース `sushanshan_bot` 上の 3 種類のキー（`sheet_info:v2:` TTL 5 分 / `chat_history:v2:` 20 件・64KB 上限・TTL `HISTORY_TTL_SECONDS` / `error_reported:` TTL 1 時間）と、KV 障害時にキャッシュミス扱いで degrade する挙動
- Analytics Engine メトリクスと `METRICS` 未設定時の `NoOpMetricsClient` フォールバックに言及
- `src/index.ts` からの `AnswerQuestionWorkflow` 再エクスポートが Cloudflare の Workflow 検出に必須である点を明記
- テストが `@cloudflare/vitest-pool-workers` 経由で Workers ランタイム上で動く点を明記

### External service errors and retries (PR #379 の内容を新規追加)
- `ExternalServiceError` と `normalizeExternalServiceError` / `externalServiceErrorFromResponse` による外部サービスエラーの統一的な包み方
- `withRetry` が既定で retryable な `ExternalServiceError` のみを再試行し、jitter 付き指数バックオフと `retryAfterMs`（`Retry-After` ヘッダ由来）を尊重すること、`sleep`/`random` が注入可能でテストが実時間を待たないこと
- `isRetryableStatus` の対象（408 / 429 / 5xx / status 不明）
- ログは `getExternalErrorLogContext`、ユーザー向け文言は `getUserMessage` を使う規約

### Project Structure (セクションごと新規追加)
- `src/` 配下（`clients/`, `discord/`, `middleware/`, `repositories/`, `responses/`, `utils/`, `workflows/` と各トップレベルファイル）および `scripts/` の構成と役割を追加。テストが `*.test.ts` として同居している点も明記

### Cloudflare Bindings (セクションごと新規追加)
- `sushanshan_bot`(KV)、`ANSWER_QUESTION_WORKFLOW`(Workflow)、`METRICS`(Analytics Engine、任意)、Cron トリガー `*/5 * * * *` を追加。従来 CLAUDE.md には wrangler.toml のバインディングに関する記述が一切ありませんでした

### Development Commands
- `npm run cf-typegen` を追加（既存の記載内容は package.json と一致していたため変更なし）

### 変更なしを確認した項目
- Environment Variables の必須/任意の変数一覧は `src/config.ts` および `src/contracts.ts` の `Bindings` と一致

---
Auto-generated by docs-sync workflow.