### PR TITLE
refactor: Discord配信を文字数制限・Rate Limit・失敗に強くする

### DIFF
--- a/src/clients/metrics.test.ts
+++ b/src/clients/metrics.test.ts
@@ -212,14 +212,17 @@ describe("MetricsClient", () => {
 				durationMs: 200,
 				retryCount: 0,
 				statusCode: 200,
+				editCount: 2,
+				chunkCount: 3,
+				deliveryStatus: "success",
 			};
 
 			metrics.recordDiscordWebhook(data);
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
 				indexes: ["req_discord"],
-				blobs: ["discord_webhook", "req_discord"],
-				doubles: [200, 1, 0, 200],
+				blobs: ["discord_webhook", "req_discord", "success"],
+				doubles: [200, 1, 0, 200, 2, 3],
 			});
 		});
 
@@ -230,14 +233,17 @@ describe("MetricsClient", () => {
 				durationMs: 3000,
 				retryCount: 2,
 				statusCode: 500,
+				editCount: 1,
+				chunkCount: 2,
+				deliveryStatus: "partial",
 			};
 
 			metrics.recordDiscordWebhook(data);
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
 				indexes: ["req_discord_fail"],
-				blobs: ["discord_webhook", "req_discord_fail"],
-				doubles: [3000, 0, 2, 500],
+				blobs: ["discord_webhook", "req_discord_fail", "partial"],
+				doubles: [3000, 0, 2, 500, 1, 2],
 			});
 		});
 
@@ -253,8 +259,8 @@ describe("MetricsClient", () => {
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
 				indexes: ["req_no_status"],
-				blobs: ["discord_webhook", "req_no_status"],
-				doubles: [1000, 0, 2, 0],
+				blobs: ["discord_webhook", "req_no_status", "unknown"],
+				doubles: [1000, 0, 2, 0, 0, 0],
 			});
 		});
 	});

--- a/src/clients/metrics.ts
+++ b/src/clients/metrics.ts
@@ -1,3 +1,4 @@
+import type { DeliveryStatus } from "../discord/delivery";
 import { getErrorMessage } from "../utils/errors";
 import { logger as defaultLogger, type Logger } from "../utils/logger";
 
@@ -42,6 +43,9 @@ export interface KVCacheMetricData extends MetricData {
 export interface DiscordWebhookMetricData extends MetricData {
 	retryCount: number;
 	statusCode?: number;
+	editCount?: number;
+	chunkCount?: number;
+	deliveryStatus?: DeliveryStatus;
 }
 
 /**
@@ -134,17 +138,19 @@ export class MetricsClient implements IMetricsClient {
 
 	/**
 	 * Record Discord webhook metrics
-	 * doubles: [durationMs, success, retryCount, statusCode]
+	 * doubles: [durationMs, success, retryCount, statusCode, editCount, chunkCount]
 	 */
 	recordDiscordWebhook(data: DiscordWebhookMetricData): void {
 		this.writeDataPoint("discord_webhook", {
 			indexes: [data.requestId.substring(0, 96)],
-			blobs: [data.requestId],
+			blobs: [data.requestId, data.deliveryStatus ?? "unknown"],
 			doubles: [
 				data.durationMs,
 				data.success ? 1 : 0,
 				data.retryCount,
 				data.statusCode ?? 0,
+				data.editCount ?? 0,
+				data.chunkCount ?? 0,
 			],
 		});
 	}

--- a/src/discord/delivery.test.ts
+++ b/src/discord/delivery.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "vitest";
+import { ExternalServiceError } from "../utils/errors";
+import type { Logger } from "../utils/logger";
+import { DiscordDeliveryService } from "./delivery";
+
+const log = {
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn(),
+} as unknown as Logger;
+
+function discordError(
+	status: number,
+	options: { retryable?: boolean; retryAfterMs?: number } = {},
+) {
+	return new ExternalServiceError({
+		service: "discord",
+		operation: "deliver message",
+		status,
+		retryable: options.retryable ?? (status === 429 || status >= 500),
+		userMessage: "Discordへの配信に失敗しました。",
+		retryAfterMs: options.retryAfterMs,
+	});
+}
+
+function createService() {
+	const transport = {
+		editOriginalMessage: vi.fn().mockResolvedValue(undefined),
+		postMessage: vi.fn().mockResolvedValue(undefined),
+	};
+	const sleep = vi.fn().mockResolvedValue(undefined);
+	const service = new DiscordDeliveryService(transport, log, {
+		sleep,
+		random: () => 0,
+	});
+	return { service, transport, sleep };
+}
+
+describe("DiscordDeliveryService", () => {
+	it("returns an empty typed result for empty content", async () => {
+		const { service, transport } = createService();
+
+		await expect(service.deliverFinal("")).resolves.toEqual({
+			status: "empty",
+			success: false,
+			editCount: 0,
+			chunkCount: 0,
+			failedChunks: [],
+			retryCount: 0,
+		});
+		expect(transport.editOriginalMessage).not.toHaveBeenCalled();
+		expect(transport.postMessage).not.toHaveBeenCalled();
+	});
+
+	it("edits only the first chunk for a streaming preview", async () => {
+		const { service, transport } = createService();
+		const content = "a".repeat(4000);
+
+		const result = await service.deliverPreview(content);
+
+		expect(transport.editOriginalMessage).toHaveBeenCalledWith(
+			"a".repeat(2000),
+		);
+		expect(transport.postMessage).not.toHaveBeenCalled();
+		expect(result).toMatchObject({
+			status: "success",
+			editCount: 1,
+			chunkCount: 0,
+		});
+	});
+
+	it("edits the original then posts all remaining chunks in order", async () => {
+		const { service, transport } = createService();
+		const content = `${"a".repeat(2000)}${"b".repeat(2000)}${"c".repeat(100)}`;
+
+		const result = await service.deliverFinal(content);
+
+		expect(transport.editOriginalMessage).toHaveBeenCalledWith(
+			"a".repeat(2000),
+		);
+		expect(transport.postMessage.mock.calls).toEqual([
+			["b".repeat(2000)],
+			["c".repeat(100)],
+		]);
+		expect(result).toEqual({
+			status: "success",
+			success: true,
+			editCount: 1,
+			chunkCount: 2,
+			failedChunks: [],
+			retryCount: 0,
+			statusCode: 200,
+		});
+	});
+
+	it("continues after a middle chunk fails and reports a partial result", async () => {
+		const { service, transport } = createService();
+		transport.postMessage
+			.mockResolvedValueOnce(undefined)
+			.mockRejectedValueOnce(discordError(400, { retryable: false }))
+			.mockResolvedValueOnce(undefined);
+		const content = [
+			"a".repeat(2000),
+			"b".repeat(2000),
+			"c".repeat(2000),
+			"d".repeat(2000),
+		].join("");
+
+		const result = await service.deliverFinal(content);
+
+		expect(transport.postMessage).toHaveBeenCalledTimes(3);
+		expect(result).toEqual({
+			status: "partial",
+			success: false,
+			editCount: 1,
+			chunkCount: 2,
+			failedChunks: [2],
+			retryCount: 0,
+			statusCode: 400,
+		});
+	});
+
+	it("does not increment editCount when the final edit fails", async () => {
+		const { service, transport } = createService();
+		transport.editOriginalMessage.mockRejectedValue(
+			discordError(400, { retryable: false }),
+		);
+
+		const result = await service.deliverFinal("answer");
+
+		expect(result).toMatchObject({
+			status: "failed",
+			success: false,
+			editCount: 0,
+			chunkCount: 0,
+			failedChunks: [0],
+			statusCode: 400,
+		});
+	});
+
+	it("retries 429 with Retry-After", async () => {
+		const { service, transport, sleep } = createService();
+		transport.editOriginalMessage
+			.mockRejectedValueOnce(
+				discordError(429, { retryable: true, retryAfterMs: 2500 }),
+			)
+			.mockResolvedValueOnce(undefined);
+
+		const result = await service.deliverFinal("answer");
+
+		expect(transport.editOriginalMessage).toHaveBeenCalledTimes(2);
+		expect(sleep).toHaveBeenCalledWith(2500);
+		expect(result.retryCount).toBe(1);
+		expect(result.success).toBe(true);
+	});
+
+	it("retries 5xx but does not retry permanent 4xx", async () => {
+		const retryable = createService();
+		retryable.transport.postMessage
+			.mockRejectedValueOnce(discordError(500))
+			.mockResolvedValueOnce(undefined);
+
+		await expect(
+			retryable.service.deliverFollowup("answer"),
+		).resolves.toMatchObject({ success: true, retryCount: 1 });
+		expect(retryable.transport.postMessage).toHaveBeenCalledTimes(2);
+
+		const permanent = createService();
+		permanent.transport.postMessage.mockRejectedValue(
+			discordError(403, { retryable: false }),
+		);
+
+		await expect(
+			permanent.service.deliverFollowup("answer"),
+		).resolves.toMatchObject({
+			status: "failed",
+			success: false,
+			retryCount: 0,
+			statusCode: 403,
+		});
+		expect(permanent.transport.postMessage).toHaveBeenCalledTimes(1);
+		expect(permanent.sleep).not.toHaveBeenCalled();
+	});
+});

--- a/src/discord/delivery.ts
+++ b/src/discord/delivery.ts
@@ -1,0 +1,237 @@
+import {
+	ExternalServiceError,
+	getExternalErrorLogContext,
+} from "../utils/errors";
+import { logger as defaultLogger, type Logger } from "../utils/logger";
+import { type RetryConfig, withRetry } from "../utils/retry";
+import { splitContent } from "./formatter";
+
+export type DeliveryStatus = "success" | "empty" | "partial" | "failed";
+
+export interface DeliveryResult {
+	status: DeliveryStatus;
+	success: boolean;
+	editCount: number;
+	chunkCount: number;
+	failedChunks: number[];
+	retryCount: number;
+	statusCode?: number;
+}
+
+export interface DiscordWebhookTransport {
+	editOriginalMessage(content: string): Promise<void>;
+	postMessage(content: string): Promise<void>;
+}
+
+const DEFAULT_DISCORD_RETRY_CONFIG: Partial<RetryConfig> = {
+	maxAttempts: 3,
+	initialDelayMs: 1000,
+	maxDelayMs: 10_000,
+	backoffMultiplier: 2,
+};
+
+interface DeliveryAttempt {
+	success: boolean;
+	retryCount: number;
+	statusCode?: number;
+}
+
+function deliveryStatus(
+	successfulCalls: number,
+	failedChunks: number[],
+): DeliveryStatus {
+	if (failedChunks.length === 0) {
+		return "success";
+	}
+	return successfulCalls === 0 ? "failed" : "partial";
+}
+
+export class DiscordDeliveryService {
+	private transport: DiscordWebhookTransport;
+	private log: Logger;
+	private retryConfig: Partial<RetryConfig>;
+
+	constructor(
+		transport: DiscordWebhookTransport,
+		log?: Logger,
+		retryConfig: Partial<RetryConfig> = {},
+	) {
+		this.transport = transport;
+		this.log = log ?? defaultLogger;
+		this.retryConfig = {
+			...DEFAULT_DISCORD_RETRY_CONFIG,
+			...retryConfig,
+		};
+	}
+
+	async deliverPreview(content: string): Promise<DeliveryResult> {
+		const [preview] = splitContent(content);
+		if (preview === undefined) {
+			return this.emptyResult();
+		}
+
+		const attempt = await this.attemptDelivery(
+			() => this.transport.editOriginalMessage(preview),
+			"preview edit",
+			0,
+		);
+		const failedChunks = attempt.success ? [] : [0];
+
+		return {
+			status: attempt.success ? "success" : "failed",
+			success: attempt.success,
+			editCount: attempt.success ? 1 : 0,
+			chunkCount: 0,
+			failedChunks,
+			retryCount: attempt.retryCount,
+			statusCode: attempt.statusCode,
+		};
+	}
+
+	async deliverFinal(content: string): Promise<DeliveryResult> {
+		const chunks = splitContent(content);
+		if (chunks.length === 0) {
+			return this.emptyResult();
+		}
+
+		let editCount = 0;
+		let chunkCount = 0;
+		let retryCount = 0;
+		let statusCode: number | undefined = 200;
+		const failedChunks: number[] = [];
+
+		const editAttempt = await this.attemptDelivery(
+			() => this.transport.editOriginalMessage(chunks[0] as string),
+			"final edit",
+			0,
+		);
+		retryCount += editAttempt.retryCount;
+		if (editAttempt.success) {
+			editCount++;
+		} else {
+			failedChunks.push(0);
+			statusCode = editAttempt.statusCode;
+		}
+
+		for (let index = 1; index < chunks.length; index++) {
+			const chunk = chunks[index] as string;
+			const followupAttempt = await this.attemptDelivery(
+				() => this.transport.postMessage(chunk),
+				"follow-up message",
+				index,
+			);
+			retryCount += followupAttempt.retryCount;
+			if (followupAttempt.success) {
+				chunkCount++;
+			} else {
+				failedChunks.push(index);
+				statusCode = followupAttempt.statusCode;
+			}
+		}
+
+		const status = deliveryStatus(editCount + chunkCount, failedChunks);
+		return {
+			status,
+			success: status === "success",
+			editCount,
+			chunkCount,
+			failedChunks,
+			retryCount,
+			statusCode,
+		};
+	}
+
+	async deliverFollowup(content: string): Promise<DeliveryResult> {
+		const chunks = splitContent(content);
+		if (chunks.length === 0) {
+			return this.emptyResult();
+		}
+
+		let chunkCount = 0;
+		let retryCount = 0;
+		let statusCode: number | undefined = 200;
+		const failedChunks: number[] = [];
+
+		for (let index = 0; index < chunks.length; index++) {
+			const chunk = chunks[index] as string;
+			const attempt = await this.attemptDelivery(
+				() => this.transport.postMessage(chunk),
+				"follow-up message",
+				index,
+			);
+			retryCount += attempt.retryCount;
+			if (attempt.success) {
+				chunkCount++;
+			} else {
+				failedChunks.push(index);
+				statusCode = attempt.statusCode;
+			}
+		}
+
+		const status = deliveryStatus(chunkCount, failedChunks);
+		return {
+			status,
+			success: status === "success",
+			editCount: 0,
+			chunkCount,
+			failedChunks,
+			retryCount,
+			statusCode,
+		};
+	}
+
+	private emptyResult(): DeliveryResult {
+		return {
+			status: "empty",
+			success: false,
+			editCount: 0,
+			chunkCount: 0,
+			failedChunks: [],
+			retryCount: 0,
+		};
+	}
+
+	private async attemptDelivery(
+		operation: () => Promise<void>,
+		operationName: string,
+		chunkIndex: number,
+	): Promise<DeliveryAttempt> {
+		let attemptCount = 0;
+		try {
+			await withRetry(
+				async () => {
+					attemptCount++;
+					await operation();
+				},
+				this.retryConfig,
+				undefined,
+				this.log,
+			);
+			return {
+				success: true,
+				retryCount: attemptCount - 1,
+				statusCode: 200,
+			};
+		} catch (error) {
+			this.log.warn("Discord delivery failed", {
+				deliveryOperation: operationName,
+				chunkIndex,
+				...getExternalErrorLogContext(error),
+			});
+			return {
+				success: false,
+				retryCount: Math.max(0, attemptCount - 1),
+				statusCode:
+					error instanceof ExternalServiceError ? error.status : undefined,
+			};
+		}
+	}
+}
+
+export function createDiscordDeliveryService(
+	transport: DiscordWebhookTransport,
+	log?: Logger,
+	retryConfig?: Partial<RetryConfig>,
+): DiscordDeliveryService {
+	return new DiscordDeliveryService(transport, log, retryConfig);
+}

--- a/src/discord/formatter.test.ts
+++ b/src/discord/formatter.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+	DISCORD_CONTENT_LIMIT,
+	formatAnswer,
+	formatError,
+	formatThinking,
+	splitContent,
+} from "./formatter";
+
+describe("Discord formatter", () => {
+	it("formats answer, thinking, and error content", () => {
+		expect(formatAnswer("question", "answer")).toBe("> question\nanswer");
+		expect(formatThinking("question", "summary")).toBe(
+			"> question\n:thought_balloon: summary",
+		);
+		expect(formatError("question", "failure")).toBe(
+			"> question\n:rotating_light: エラーが発生しました: failure",
+		);
+	});
+
+	it.each([0, 1, 1999, 2000])(
+		"keeps %i UTF-16 code units in one chunk",
+		(length) => {
+			const content = "a".repeat(length);
+			expect(splitContent(content)).toEqual(length === 0 ? [] : [content]);
+		},
+	);
+
+	it("splits 2001 UTF-16 code units without loss", () => {
+		const content = "a".repeat(2001);
+		const chunks = splitContent(content);
+
+		expect(chunks.map((chunk) => chunk.length)).toEqual([2000, 1]);
+		expect(chunks.join("")).toBe(content);
+	});
+
+	it("prefers newline and then space boundaries", () => {
+		expect(splitContent("1234\n56789", 6)).toEqual(["1234\n", "56789"]);
+		expect(splitContent("1234 56789", 6)).toEqual(["1234 ", "56789"]);
+	});
+
+	it("hard-splits content with no whitespace", () => {
+		const content = "a".repeat(5000);
+		const chunks = splitContent(content);
+
+		expect(chunks.map((chunk) => chunk.length)).toEqual([2000, 2000, 1000]);
+		expect(chunks.join("")).toBe(content);
+	});
+
+	it("never splits a surrogate pair at the content limit", () => {
+		const content = `${"a".repeat(DISCORD_CONTENT_LIMIT - 1)}😀tail`;
+		const chunks = splitContent(content);
+
+		expect(chunks[0]).toHaveLength(DISCORD_CONTENT_LIMIT - 1);
+		expect(chunks[1]?.startsWith("😀")).toBe(true);
+		expect(chunks.every((chunk) => chunk.length <= DISCORD_CONTENT_LIMIT)).toBe(
+			true,
+		);
+		expect(chunks.join("")).toBe(content);
+	});
+
+	it("keeps emoji content complete and ordered across chunks", () => {
+		const content = "😀".repeat(2500);
+		const chunks = splitContent(content);
+
+		expect(chunks).toHaveLength(3);
+		expect(chunks.every((chunk) => chunk.length <= DISCORD_CONTENT_LIMIT)).toBe(
+			true,
+		);
+		expect(chunks.join("")).toBe(content);
+	});
+
+	it("splits a long question and answer combination without loss", () => {
+		const content = formatAnswer("q".repeat(1990), "a".repeat(100));
+		const chunks = splitContent(content);
+
+		expect(chunks).toHaveLength(2);
+		expect(chunks.every((chunk) => chunk.length <= DISCORD_CONTENT_LIMIT)).toBe(
+			true,
+		);
+		expect(chunks.join("")).toBe(content);
+	});
+
+	it("rejects invalid limits", () => {
+		expect(() => splitContent("content", 0)).toThrow(RangeError);
+		expect(() => splitContent("😀", 1)).toThrow(RangeError);
+	});
+
+	it("supports a one-unit limit for single-unit code points", () => {
+		expect(splitContent("abc", 1)).toEqual(["a", "b", "c"]);
+	});
+});

--- a/src/discord/formatter.ts
+++ b/src/discord/formatter.ts
@@ -1,0 +1,80 @@
+export const DISCORD_CONTENT_LIMIT = 2000;
+const PREFERRED_BOUNDARY_MIN_FILL_RATIO = 0.8;
+
+export function formatAnswer(question: string, answer: string): string {
+	return `> ${question}\n${answer}`;
+}
+
+export function formatThinking(question: string, summary: string): string {
+	return `> ${question}\n:thought_balloon: ${summary}`;
+}
+
+export function formatError(question: string, errorMessage: string): string {
+	return `> ${question}\n:rotating_light: エラーが発生しました: ${errorMessage}`;
+}
+
+function safeCodePointBoundary(content: string, end: number): number {
+	if (end <= 0 || end >= content.length) {
+		return end;
+	}
+
+	const previous = content.charCodeAt(end - 1);
+	const next = content.charCodeAt(end);
+	const splitsSurrogatePair =
+		previous >= 0xd800 &&
+		previous <= 0xdbff &&
+		next >= 0xdc00 &&
+		next <= 0xdfff;
+
+	return splitsSurrogatePair ? end - 1 : end;
+}
+
+/**
+ * Split Discord content without dropping delimiters or splitting a Unicode code
+ * point. The limit is measured in UTF-16 code units, which is the conservative
+ * interpretation of Discord's content limit.
+ */
+export function splitContent(
+	content: string,
+	limit = DISCORD_CONTENT_LIMIT,
+): string[] {
+	if (!Number.isInteger(limit) || limit <= 0) {
+		throw new RangeError("Discord content limit must be a positive integer");
+	}
+	if (content.length === 0) {
+		return [];
+	}
+
+	const chunks: string[] = [];
+	let remaining = content;
+
+	while (remaining.length > limit) {
+		const hardBoundary = safeCodePointBoundary(remaining, limit);
+		if (hardBoundary === 0) {
+			throw new RangeError(
+				"Discord content limit is too small for the first Unicode code point",
+			);
+		}
+
+		const lastNewline = remaining.lastIndexOf("\n", hardBoundary - 1);
+		const lastSpace = remaining.lastIndexOf(" ", hardBoundary - 1);
+		const minimumPreferredBoundary = Math.floor(
+			hardBoundary * PREFERRED_BOUNDARY_MIN_FILL_RATIO,
+		);
+		const splitAt =
+			lastNewline >= 0 && lastNewline + 1 >= minimumPreferredBoundary
+				? lastNewline + 1
+				: lastSpace >= 0 && lastSpace + 1 >= minimumPreferredBoundary
+					? lastSpace + 1
+					: hardBoundary;
+
+		chunks.push(remaining.slice(0, splitAt));
+		remaining = remaining.slice(splitAt);
+	}
+
+	if (remaining.length > 0) {
+		chunks.push(remaining);
+	}
+
+	return chunks;
+}

--- a/src/workflows/answerQuestionWorkflow.test.ts
+++ b/src/workflows/answerQuestionWorkflow.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Bindings, HistoryEntry } from "../contracts";
+import { formatAnswer } from "../discord/formatter";
 import { ExternalServiceError } from "../utils/errors";
 import type { Logger } from "../utils/logger";
 import type { HistoryOutput, SheetDataOutput } from "./types";
@@ -363,6 +364,63 @@ describe("AnswerQuestionWorkflow Steps", () => {
 			expect(lastCall?.[0]).toBe("> user question\nfull response");
 		});
 
+		it("delivers a long final answer in ordered chunks without loss", async () => {
+			const response = "a".repeat(4500);
+			mockGeminiInstance.askStream.mockResolvedValue(response);
+			mockGeminiInstance.getHistory.mockReturnValue([]);
+			mockDiscordInstance.editOriginalMessage.mockResolvedValue(undefined);
+			mockDiscordInstance.postMessage.mockResolvedValue(undefined);
+
+			const result = await streamGeminiWithDiscordEditsStep(
+				mockEnv,
+				"test-token",
+				"question",
+				"message",
+				sheetData,
+				history,
+				mockLogger,
+			);
+
+			const deliveredChunks = [
+				mockDiscordInstance.editOriginalMessage.mock.calls[0]?.[0] as string,
+				...mockDiscordInstance.postMessage.mock.calls.map(
+					([content]) => content as string,
+				),
+			];
+			expect(deliveredChunks.every((chunk) => chunk.length <= 2000)).toBe(true);
+			expect(deliveredChunks.join("")).toBe(formatAnswer("question", response));
+			expect(result).toMatchObject({
+				editCount: 1,
+				chunkCount: 2,
+				deliveryStatus: "success",
+				failedChunks: [],
+			});
+		});
+
+		it("returns an empty delivery result for an empty Gemini answer", async () => {
+			mockGeminiInstance.askStream.mockResolvedValue("");
+			mockGeminiInstance.getHistory.mockReturnValue([]);
+
+			const result = await streamGeminiWithDiscordEditsStep(
+				mockEnv,
+				"token",
+				"question",
+				"message",
+				sheetData,
+				history,
+				mockLogger,
+			);
+
+			expect(mockDiscordInstance.editOriginalMessage).not.toHaveBeenCalled();
+			expect(mockDiscordInstance.postMessage).not.toHaveBeenCalled();
+			expect(result).toMatchObject({
+				editCount: 0,
+				chunkCount: 0,
+				deliveryStatus: "empty",
+				failedChunks: [],
+			});
+		});
+
 		it("displays summarized thinking content with thought balloon", async () => {
 			mockGenerateContent.mockResolvedValue({
 				candidates: [
@@ -702,7 +760,15 @@ describe("AnswerQuestionWorkflow Steps", () => {
 			expect(mockDiscordInstance.postMessage).toHaveBeenCalledWith(
 				"> user question\nAI answer",
 			);
-			expect(result).toEqual({ success: true, statusCode: 200, retryCount: 0 });
+			expect(result).toEqual({
+				success: true,
+				statusCode: 200,
+				retryCount: 0,
+				editCount: 0,
+				chunkCount: 1,
+				deliveryStatus: "success",
+				failedChunks: [],
+			});
 		});
 
 		it("sends error response when AI fails", async () => {
@@ -720,7 +786,15 @@ describe("AnswerQuestionWorkflow Steps", () => {
 			expect(mockDiscordInstance.postMessage).toHaveBeenCalledWith(
 				"> question\n:rotating_light: エラーが発生しました: Some error occurred",
 			);
-			expect(result).toEqual({ success: true, statusCode: 200, retryCount: 0 });
+			expect(result).toEqual({
+				success: true,
+				statusCode: 200,
+				retryCount: 0,
+				editCount: 0,
+				chunkCount: 1,
+				deliveryStatus: "success",
+				failedChunks: [],
+			});
 		});
 
 		it("retries on failure", async () => {
@@ -740,7 +814,15 @@ describe("AnswerQuestionWorkflow Steps", () => {
 			const result = await promise;
 
 			expect(mockDiscordInstance.postMessage).toHaveBeenCalledTimes(2);
-			expect(result).toEqual({ success: true, statusCode: 200, retryCount: 1 });
+			expect(result).toEqual({
+				success: true,
+				statusCode: 200,
+				retryCount: 1,
+				editCount: 0,
+				chunkCount: 1,
+				deliveryStatus: "success",
+				failedChunks: [],
+			});
 		});
 
 		it("returns failure after all retries exhausted", async () => {
@@ -764,6 +846,10 @@ describe("AnswerQuestionWorkflow Steps", () => {
 				success: false,
 				statusCode: 500,
 				retryCount: 2,
+				editCount: 0,
+				chunkCount: 0,
+				deliveryStatus: "failed",
+				failedChunks: [0],
 			});
 		});
 
@@ -787,6 +873,10 @@ describe("AnswerQuestionWorkflow Steps", () => {
 					success: false,
 					statusCode: status,
 					retryCount: 0,
+					editCount: 0,
+					chunkCount: 0,
+					deliveryStatus: "failed",
+					failedChunks: [0],
 				});
 			},
 		);
@@ -812,6 +902,10 @@ describe("AnswerQuestionWorkflow Steps", () => {
 				success: true,
 				statusCode: 200,
 				retryCount: 1,
+				editCount: 0,
+				chunkCount: 1,
+				deliveryStatus: "success",
+				failedChunks: [],
 			});
 			expect(mockLogger.warn).toHaveBeenCalledWith(
 				"Retrying external service request",

--- a/src/workflows/answerQuestionWorkflow.ts
+++ b/src/workflows/answerQuestionWorkflow.ts
@@ -15,18 +15,22 @@ import {
 import { getSheetData } from "../clients/spreadSheet";
 import { DEFAULT_RUNTIME_CONFIG, loadConfig } from "../config";
 import type { Bindings, HistoryEntry } from "../contracts";
+import { createDiscordDeliveryService } from "../discord/delivery";
+import {
+	formatAnswer,
+	formatError,
+	formatThinking,
+} from "../discord/formatter";
 import { createConversationHistoryRepository } from "../repositories/conversationHistory";
 import { createDeduplicationStore } from "../repositories/deduplicationStore";
 import { createSheetCacheRepository } from "../repositories/sheetCache";
 import {
-	ExternalServiceError,
 	getErrorMessage,
 	getExternalErrorLogContext,
 	getUserMessage,
 	normalizeExternalServiceError,
 } from "../utils/errors";
 import { type Logger, logger } from "../utils/logger";
-import { withRetry } from "../utils/retry";
 import type {
 	DiscordResponseOutput,
 	HistoryOutput,
@@ -149,12 +153,6 @@ const THINKING_EDIT_INTERVAL_MS = 1000;
 const THINKING_MIN_CHUNK_SIZE = 200;
 
 const THINKING_FALLBACK = "考え中...";
-const DISCORD_RETRY_CONFIG = {
-	maxAttempts: 3,
-	initialDelayMs: 1000,
-	maxDelayMs: 10_000,
-	backoffMultiplier: 2,
-};
 
 export async function summarizeThinking(
 	client: GoogleGenAI,
@@ -208,6 +206,7 @@ export async function streamGeminiWithDiscordEditsStep(
 		token,
 		log,
 	);
+	const delivery = createDiscordDeliveryService(discord, log);
 	const gemini = createGeminiClient(
 		config.geminiApiKey,
 		historyOutput.history,
@@ -220,12 +219,10 @@ export async function streamGeminiWithDiscordEditsStep(
 	let lastThinkingEditLength = 0;
 	let lastResponseEditLength = 0;
 	let editCount = 0;
+	let retryCount = 0;
+	let deliveryDurationMs = 0;
 	let currentPhase: "thinking" | "response" = "thinking";
 	let accumulatedThinking = "";
-
-	const formatContent = (text: string) => `> ${question}\n${text}`;
-	const formatThinkingContent = (summary: string) =>
-		`> ${question}\n:thought_balloon: ${summary}`;
 
 	const onChunk = async (
 		accumulatedText: string,
@@ -268,7 +265,8 @@ export async function streamGeminiWithDiscordEditsStep(
 		) {
 			const content =
 				phase === "thinking"
-					? formatThinkingContent(
+					? formatThinking(
+							question,
 							await summarizeThinking(
 								summarizer,
 								accumulatedThinking,
@@ -276,30 +274,31 @@ export async function streamGeminiWithDiscordEditsStep(
 								config.geminiSummaryModel,
 							),
 						)
-					: formatContent(accumulatedText);
+					: formatAnswer(question, accumulatedText);
 
-			try {
-				await withRetry(
-					async () => await discord.editOriginalMessage(content),
-					DISCORD_RETRY_CONFIG,
-					undefined,
-					log,
-				);
+			const deliveryStartTime = Date.now();
+			const result = await delivery.deliverPreview(content);
+			deliveryDurationMs += Date.now() - deliveryStartTime;
+			editCount += result.editCount;
+			retryCount += result.retryCount;
+
+			if (result.success) {
 				lastEditTime = now;
 				if (phase === "thinking") {
 					lastThinkingEditLength = accumulatedThinking.length;
 				} else {
 					lastResponseEditLength = accumulatedText.length;
 				}
-				editCount++;
 				log.debug("Discord message edited", {
 					editCount,
 					phase,
 					contentLength: textLength,
 				});
-			} catch (error) {
+			} else {
 				log.warn("Intermediate Discord edit failed (non-fatal)", {
-					...getExternalErrorLogContext(error),
+					deliveryStatus: result.status,
+					failedChunks: result.failedChunks,
+					statusCode: result.statusCode,
 				});
 			}
 		}
@@ -313,16 +312,19 @@ export async function streamGeminiWithDiscordEditsStep(
 		onChunk,
 	);
 
-	// Final edit to ensure complete response is shown (response only, no thinking)
-	await withRetry(
-		async () => await discord.editOriginalMessage(formatContent(response)),
-		DISCORD_RETRY_CONFIG,
-		undefined,
-		log,
+	const finalDeliveryStartTime = Date.now();
+	const finalDelivery = await delivery.deliverFinal(
+		response.length === 0 ? "" : formatAnswer(question, response),
 	);
-	editCount++;
-	log.info("Final Discord edit sent", {
+	deliveryDurationMs += Date.now() - finalDeliveryStartTime;
+	editCount += finalDelivery.editCount;
+	retryCount += finalDelivery.retryCount;
+
+	log.info("Final Discord delivery completed", {
 		editCount,
+		chunkCount: finalDelivery.chunkCount,
+		deliveryStatus: finalDelivery.status,
+		failedChunks: finalDelivery.failedChunks,
 		responseLength: response.length,
 	});
 
@@ -330,6 +332,12 @@ export async function streamGeminiWithDiscordEditsStep(
 		response,
 		updatedHistory: gemini.getHistory(),
 		editCount,
+		chunkCount: finalDelivery.chunkCount,
+		deliveryStatus: finalDelivery.status,
+		failedChunks: finalDelivery.failedChunks,
+		retryCount,
+		statusCode: finalDelivery.statusCode,
+		deliveryDurationMs,
 	};
 }
 
@@ -348,46 +356,22 @@ export async function sendDiscordResponseStep(
 		token,
 		log,
 	);
+	const delivery = createDiscordDeliveryService(discord, log);
 
 	const content = errorMessage
-		? `> ${question}\n:rotating_light: エラーが発生しました: ${errorMessage}`
-		: `> ${question}\n${response}`;
+		? formatError(question, errorMessage)
+		: formatAnswer(question, response ?? "");
 
-	let attemptCount = 0;
-	let statusCode: number | undefined;
-
-	try {
-		await withRetry(
-			async () => {
-				attemptCount++;
-				await discord.postMessage(content);
-				statusCode = 200; // Success status
-			},
-			{
-				maxAttempts: 3, // Initial attempt + 2 retries
-				initialDelayMs: 1000,
-				backoffMultiplier: 2,
-			},
-			undefined,
-			log,
-		);
-
-		return {
-			success: true,
-			statusCode: statusCode ?? 200,
-			retryCount: attemptCount - 1, // retryCount = attempts - 1
-		};
-	} catch (error) {
-		if (error instanceof ExternalServiceError) {
-			statusCode = error.status;
-		}
-
-		return {
-			success: false,
-			statusCode,
-			retryCount: attemptCount > 0 ? attemptCount - 1 : 2, // Max retries is 2
-		};
-	}
+	const result = await delivery.deliverFollowup(content);
+	return {
+		success: result.success,
+		statusCode: result.statusCode,
+		retryCount: result.retryCount,
+		editCount: result.editCount,
+		chunkCount: result.chunkCount,
+		deliveryStatus: result.status,
+		failedChunks: result.failedChunks,
+	};
 }
 
 const ERROR_REPORTED_TTL_SECONDS = 60 * 60; // 1 hour
@@ -540,6 +524,17 @@ export class AnswerQuestionWorkflow extends WorkflowEntrypoint<
 				});
 			}
 
+			metrics.recordDiscordWebhook({
+				requestId,
+				success: streamResult.deliveryStatus === "success",
+				durationMs: streamResult.deliveryDurationMs,
+				retryCount: streamResult.retryCount,
+				statusCode: streamResult.statusCode,
+				editCount: streamResult.editCount,
+				chunkCount: streamResult.chunkCount,
+				deliveryStatus: streamResult.deliveryStatus,
+			});
+
 			// Step 4: Save history
 			await step.do("saveHistory", async () => {
 				return saveHistoryStep(
@@ -619,6 +614,9 @@ export class AnswerQuestionWorkflow extends WorkflowEntrypoint<
 				durationMs: Date.now() - discordErrorStartTime,
 				retryCount: discordErrorResult.retryCount,
 				statusCode: discordErrorResult.statusCode,
+				editCount: discordErrorResult.editCount,
+				chunkCount: discordErrorResult.chunkCount,
+				deliveryStatus: discordErrorResult.deliveryStatus,
 			});
 		}
 	}

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -1,4 +1,5 @@
 import type { HistoryEntry } from "../contracts";
+import type { DeliveryStatus } from "../discord/delivery";
 
 export type { WorkflowParams } from "../contracts";
 
@@ -17,6 +18,12 @@ export interface StreamingGeminiOutput {
 	response: string;
 	updatedHistory: HistoryEntry[];
 	editCount: number;
+	chunkCount: number;
+	deliveryStatus: DeliveryStatus;
+	failedChunks: number[];
+	retryCount: number;
+	statusCode?: number;
+	deliveryDurationMs: number;
 }
 
 export interface SaveHistoryOutput {
@@ -27,4 +34,8 @@ export interface DiscordResponseOutput {
 	success: boolean;
 	statusCode?: number;
 	retryCount: number;
+	editCount: number;
+	chunkCount: number;
+	deliveryStatus: DeliveryStatus;
+	failedChunks: number[];
 }


### PR DESCRIPTION
Refs #364
Parent: #358

## 概要

Discord の表示整形・文字数分割と API 配信ポリシーを分離し、長文回答、Rate Limit、部分失敗を安全に扱えるようにします。

## 変更内容

- Discord content を UTF-16 で最大 2000 文字に制限し、Unicode code point を壊さず、改行・空白境界を優先して欠落なく分割
- streaming preview は original message の先頭 chunk だけを edit
- final answer は先頭 chunk を original message に editし、残りを follow-up として順番に送信
- 429 / 5xx / network error のみ共通 retry policy で再試行し、Retry-After を尊重
- 成功した edit / follow-up だけを計測し、empty / partial / failed と失敗 chunk を型付き結果で返却
- Discord metrics に delivery status、edit count、chunk count を追加

## 責務の変更前後

変更前は Workflow が表示整形、retry、API 呼び出し、成功数の加算を直接担当していました。変更後は formatter が表示と分割、DiscordDeliveryService が retry・送信順序・部分失敗を担当し、Workflow は配信結果の集約と記録だけを行います。

## 互換性

- 既存の `/ask` 表示形式、Discord PING、署名検証、遅延応答は変更しません
- 2000 文字以内の回答は従来どおり original message に表示されます
- 新しい永続ストレージや migration はありません
- Analytics Engine の既存 doubles / blobs の位置は維持し、末尾に配信情報を追加します
- Workflow の Discord streaming step は retry limit 0 のまま維持し、送信済み follow-up のステップ再実行による重複を防ぎます

## 検証

- `npm run verify`
  - Biome check
  - TypeScript typecheck
  - Vitest: 21 files / 279 tests passed
  - Wrangler deploy dry-run

境界値 0 / 1 / 1999 / 2000 / 2001、長い question + answer、改行・空白・hard split、surrogate pair / emoji、original + 複数 follow-up の順序と完全再結合、429 Retry-After、5xx、恒久 4xx、final edit 失敗、途中 chunk 失敗をテストしています。

## ロールバック

この PR の commit を revert します。データ migration や永続状態の変更はないため、コードの切り戻しだけで復旧できます。