### PR TITLE
Reduce Gemini inference cost

### DIFF
--- a/src/clients/metrics.test.ts
+++ b/src/clients/metrics.test.ts
@@ -52,8 +52,8 @@ describe("MetricsClient", () => {
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
 				indexes: ["req_abc123"],
-				blobs: ["gemini_api_call", "req_abc123"],
-				doubles: [1500, 1, 0, 0, 0, 0, 0, 0],
+				blobs: ["gemini_api_call", "req_abc123", "unknown", "answer"],
+				doubles: [1500, 1, 0, 0, 0, 0, 0, 0, 1],
 			});
 		});
 
@@ -69,8 +69,8 @@ describe("MetricsClient", () => {
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
 				indexes: ["req_xyz789"],
-				blobs: ["gemini_api_call", "req_xyz789"],
-				doubles: [500, 0, 2, 0, 0, 0, 0, 0],
+				blobs: ["gemini_api_call", "req_xyz789", "unknown", "answer"],
+				doubles: [500, 0, 2, 0, 0, 0, 0, 0, 1],
 			});
 		});
 
@@ -85,8 +85,8 @@ describe("MetricsClient", () => {
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
 				indexes: ["req_123"],
-				blobs: ["gemini_api_call", "req_123"],
-				doubles: [100, 1, 0, 0, 0, 0, 0, 0],
+				blobs: ["gemini_api_call", "req_123", "unknown", "answer"],
+				doubles: [100, 1, 0, 0, 0, 0, 0, 0, 1],
 			});
 		});
 
@@ -102,8 +102,8 @@ describe("MetricsClient", () => {
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
 				indexes: [longRequestId.substring(0, 96)],
-				blobs: ["gemini_api_call", longRequestId],
-				doubles: [100, 1, 0, 0, 0, 0, 0, 0],
+				blobs: ["gemini_api_call", longRequestId, "unknown", "answer"],
+				doubles: [100, 1, 0, 0, 0, 0, 0, 0, 1],
 			});
 		});
 
@@ -113,6 +113,9 @@ describe("MetricsClient", () => {
 				success: true,
 				durationMs: 250,
 				retryCount: 1,
+				model: "gemini-3.5-flash-lite",
+				purpose: "thinking_summary",
+				callCount: 3,
 				usage: {
 					promptTokens: 100,
 					cachedTokens: 50,
@@ -124,8 +127,13 @@ describe("MetricsClient", () => {
 
 			expect(mockDataset.writeDataPoint).toHaveBeenCalledWith({
 				indexes: ["req_usage"],
-				blobs: ["gemini_api_call", "req_usage"],
-				doubles: [250, 1, 1, 100, 50, 10, 20, 130],
+				blobs: [
+					"gemini_api_call",
+					"req_usage",
+					"gemini-3.5-flash-lite",
+					"thinking_summary",
+				],
+				doubles: [250, 1, 1, 100, 50, 10, 20, 130, 3],
 			});
 		});
 	});

--- a/src/clients/metrics.ts
+++ b/src/clients/metrics.ts
@@ -29,6 +29,9 @@ export interface MetricData {
 export interface GeminiMetricData extends MetricData {
 	retryCount?: number;
 	usage?: GeminiUsage | null;
+	model?: string;
+	purpose?: "answer" | "thinking_summary";
+	callCount?: number;
 }
 
 /**
@@ -85,7 +88,7 @@ export interface IMetricsClient {
  *
  * Data point structure:
  * - indexes: [requestId] (max 96 bytes, for efficient queries)
- * - blobs: [eventType, requestId, ...additional context]
+ * - blobs: [eventType, requestId, model, purpose, ...additional context]
  * - doubles: [durationMs, success (1/0), ...additional metrics]
  */
 export class MetricsClient implements IMetricsClient {
@@ -100,13 +103,17 @@ export class MetricsClient implements IMetricsClient {
 	/**
 	 * Record Gemini API call metrics
 	 * doubles: [durationMs, success, retryCount, promptTokens, cachedTokens,
-	 *   thoughtsTokens, candidatesTokens, totalTokens]
+	 *   thoughtsTokens, candidatesTokens, totalTokens, callCount]
 	 */
 	recordGeminiCall(data: GeminiMetricData): void {
 		const usage = data.usage;
 		this.writeDataPoint("gemini_api_call", {
 			indexes: [data.requestId.substring(0, 96)],
-			blobs: [data.requestId],
+			blobs: [
+				data.requestId,
+				data.model ?? "unknown",
+				data.purpose ?? "answer",
+			],
 			doubles: [
 				data.durationMs,
 				data.success ? 1 : 0,
@@ -116,6 +123,7 @@ export class MetricsClient implements IMetricsClient {
 				usage?.thoughtsTokens ?? 0,
 				usage?.candidatesTokens ?? 0,
 				usage?.totalTokens ?? 0,
+				data.callCount ?? 1,
 			],
 		});
 	}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -19,6 +19,7 @@ describe("loadConfig", () => {
 	it("uses backward-compatible defaults for optional settings", () => {
 		const config = loadConfig(createBindings());
 
+		expect(DEFAULT_RUNTIME_CONFIG.geminiModel).toBe("gemini-3.5-flash-lite");
 		expect(config).toMatchObject({
 			geminiModel: DEFAULT_RUNTIME_CONFIG.geminiModel,
 			geminiSummaryModel: DEFAULT_RUNTIME_CONFIG.geminiSummaryModel,

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ const HISTORY_TTL_MIN_SECONDS = 60;
 const HISTORY_TTL_MAX_SECONDS = 86_400;
 
 export const DEFAULT_RUNTIME_CONFIG = {
-	geminiModel: "gemini-3.6-flash",
+	geminiModel: "gemini-3.5-flash-lite",
 	geminiSummaryModel: "gemini-2.5-flash-lite",
 	spreadsheet: {
 		id: "1sPOk2XqSB3ZB-O0eKl2ZkKYVr_OgvVCZX0xS79FTNfg",

--- a/src/gemini/gateway.test.ts
+++ b/src/gemini/gateway.test.ts
@@ -6,7 +6,7 @@ const mockGenerateContent = vi.fn();
 const mockGenerateContentStream = vi.fn();
 
 vi.mock("@google/genai", () => ({
-	ThinkingLevel: { MINIMAL: "MINIMAL" },
+	ThinkingLevel: { LOW: "LOW" },
 	GoogleGenAI: vi.fn(
 		class {
 			models = {
@@ -78,7 +78,7 @@ describe("GeminiGateway", () => {
 				maxOutputTokens: 8192,
 				thinkingConfig: {
 					includeThoughts: true,
-					thinkingLevel: "MINIMAL",
+					thinkingLevel: "LOW",
 				},
 			}),
 		});

--- a/src/gemini/gateway.test.ts
+++ b/src/gemini/gateway.test.ts
@@ -6,6 +6,7 @@ const mockGenerateContent = vi.fn();
 const mockGenerateContentStream = vi.fn();
 
 vi.mock("@google/genai", () => ({
+	ThinkingLevel: { MINIMAL: "MINIMAL" },
 	GoogleGenAI: vi.fn(
 		class {
 			models = {
@@ -74,9 +75,22 @@ describe("GeminiGateway", () => {
 			contents: prompt.contents,
 			config: expect.objectContaining({
 				systemInstruction: "system",
-				thinkingConfig: { includeThoughts: true },
+				maxOutputTokens: 8192,
+				thinkingConfig: {
+					includeThoughts: true,
+					thinkingLevel: "MINIMAL",
+				},
 			}),
 		});
+		expect(
+			mockGenerateContentStream.mock.calls[0]?.[0].config,
+		).not.toHaveProperty("temperature");
+		expect(
+			mockGenerateContentStream.mock.calls[0]?.[0].config,
+		).not.toHaveProperty("topP");
+		expect(
+			mockGenerateContentStream.mock.calls[0]?.[0].config,
+		).not.toHaveProperty("topK");
 	});
 
 	it("emits typed thinking, accumulated response, and usage events", async () => {

--- a/src/gemini/gateway.ts
+++ b/src/gemini/gateway.ts
@@ -1,6 +1,7 @@
 import {
 	type GenerateContentResponseUsageMetadata,
 	GoogleGenAI,
+	ThinkingLevel,
 } from "@google/genai";
 import {
 	ExternalServiceError,
@@ -18,13 +19,11 @@ import type {
 } from "./types";
 
 const ANSWER_GENERATION_CONFIG = {
-	temperature: 1,
-	topP: 0.95,
-	topK: 40,
 	maxOutputTokens: 8192,
 	responseMimeType: "text/plain",
 	thinkingConfig: {
 		includeThoughts: true,
+		thinkingLevel: ThinkingLevel.MINIMAL,
 	},
 };
 

--- a/src/gemini/gateway.ts
+++ b/src/gemini/gateway.ts
@@ -23,7 +23,7 @@ const ANSWER_GENERATION_CONFIG = {
 	responseMimeType: "text/plain",
 	thinkingConfig: {
 		includeThoughts: true,
-		thinkingLevel: ThinkingLevel.MINIMAL,
+		thinkingLevel: ThinkingLevel.LOW,
 	},
 };
 

--- a/src/gemini/promptBuilder.test.ts
+++ b/src/gemini/promptBuilder.test.ts
@@ -38,13 +38,28 @@ describe("buildAnswerPrompt", () => {
 });
 
 describe("buildThinkingSummaryPrompt", () => {
-	it("places thought text in user content instead of the instruction", () => {
-		const prompt = buildThinkingSummaryPrompt("private thought");
+	it("places the previous summary and new thought in user content", () => {
+		const prompt = buildThinkingSummaryPrompt("前の要約", "private thought");
 
 		expect(prompt.systemInstruction).toContain("50文字以内");
 		expect(prompt.systemInstruction).not.toContain("private thought");
 		expect(prompt.contents).toEqual([
-			{ role: "user", parts: [{ text: "private thought" }] },
+			{
+				role: "user",
+				parts: [
+					{
+						text: "前回の要約:\n前の要約\n\n新しい思考内容:\nprivate thought",
+					},
+				],
+			},
 		]);
+	});
+
+	it("初回は前回の要約がないことを明示する", () => {
+		const prompt = buildThinkingSummaryPrompt("", "first thought");
+
+		expect(prompt.contents[0]?.parts[0]?.text).toContain(
+			"前回の要約:\n（なし）",
+		);
 	});
 });

--- a/src/gemini/promptBuilder.ts
+++ b/src/gemini/promptBuilder.ts
@@ -31,14 +31,21 @@ ${input.knowledge}
 	};
 }
 
-export function buildThinkingSummaryPrompt(thinkingText: string): GeminiPrompt {
+export function buildThinkingSummaryPrompt(
+	previousSummary: string,
+	newThinking: string,
+): GeminiPrompt {
 	return {
 		systemInstruction:
-			"AIの思考過程を日本語の1文（50文字以内）に要約し、要約文だけを出力してください。",
+			"前回の要約に新しい思考内容を反映し、AIの思考過程を日本語の1文（50文字以内）に要約してください。要約文だけを出力してください。",
 		contents: [
 			{
 				role: "user",
-				parts: [{ text: thinkingText }],
+				parts: [
+					{
+						text: `前回の要約:\n${previousSummary || "（なし）"}\n\n新しい思考内容:\n${newThinking}`,
+					},
+				],
 			},
 		],
 	};

--- a/src/gemini/thinkingSummarizer.test.ts
+++ b/src/gemini/thinkingSummarizer.test.ts
@@ -28,16 +28,25 @@ describe("ThinkingSummarizer", () => {
 			gateway as unknown as IGeminiGateway,
 			"summary-model",
 			log,
-		).summarize("long thought");
+		).summarize("前の要約", "new thought");
 
-		expect(result).toBe("要約結果");
+		expect(result).toEqual({ text: "要約結果", usage: null, success: true });
 		expect(gateway.generateText).toHaveBeenCalledWith(
 			expect.objectContaining({
 				model: "summary-model",
 				temperature: 0,
 				maxOutputTokens: 128,
 				prompt: expect.objectContaining({
-					contents: [{ role: "user", parts: [{ text: "long thought" }] }],
+					contents: [
+						{
+							role: "user",
+							parts: [
+								{
+									text: "前回の要約:\n前の要約\n\n新しい思考内容:\nnew thought",
+								},
+							],
+						},
+					],
 				}),
 			}),
 		);
@@ -51,8 +60,12 @@ describe("ThinkingSummarizer", () => {
 				gateway as unknown as IGeminiGateway,
 				"model",
 				log,
-			).summarize("thought"),
-		).resolves.toBe(THINKING_FALLBACK);
+			).summarize("", "thought"),
+		).resolves.toEqual({
+			text: THINKING_FALLBACK,
+			usage: null,
+			success: false,
+		});
 	});
 
 	it("returns fallback when summary generation fails", async () => {
@@ -63,8 +76,12 @@ describe("ThinkingSummarizer", () => {
 				gateway as unknown as IGeminiGateway,
 				"model",
 				log,
-			).summarize("thought"),
-		).resolves.toBe(THINKING_FALLBACK);
+			).summarize("", "thought"),
+		).resolves.toEqual({
+			text: THINKING_FALLBACK,
+			usage: null,
+			success: false,
+		});
 		expect(log.warn).toHaveBeenCalledWith(
 			"Thinking summarization failed (non-fatal)",
 			expect.objectContaining({ service: "gemini" }),

--- a/src/gemini/thinkingSummarizer.ts
+++ b/src/gemini/thinkingSummarizer.ts
@@ -4,9 +4,15 @@ import {
 } from "../utils/errors";
 import { logger as defaultLogger, type Logger } from "../utils/logger";
 import { buildThinkingSummaryPrompt } from "./promptBuilder";
-import type { IGeminiGateway } from "./types";
+import type { GeminiUsage, IGeminiGateway } from "./types";
 
 export const THINKING_FALLBACK = "考え中...";
+
+export type ThinkingSummaryResult = {
+	text: string;
+	usage: GeminiUsage | null;
+	success: boolean;
+};
 
 export class ThinkingSummarizer {
 	constructor(
@@ -15,17 +21,20 @@ export class ThinkingSummarizer {
 		private readonly log: Logger = defaultLogger,
 	) {}
 
-	async summarize(thinkingText: string): Promise<string> {
+	async summarize(
+		previousSummary: string,
+		newThinking: string,
+	): Promise<ThinkingSummaryResult> {
 		try {
 			const result = await this.gateway.generateText({
 				model: this.model,
-				prompt: buildThinkingSummaryPrompt(thinkingText),
+				prompt: buildThinkingSummaryPrompt(previousSummary, newThinking),
 				temperature: 0,
 				maxOutputTokens: 128,
 			});
 			const summary = result.text.trim();
 			if (summary) {
-				return summary;
+				return { text: summary, usage: result.usage, success: true };
 			}
 			this.log.warn("Empty summarization result, using fallback");
 		} catch (error) {
@@ -38,7 +47,7 @@ export class ThinkingSummarizer {
 				...getExternalErrorLogContext(normalized),
 			});
 		}
-		return THINKING_FALLBACK;
+		return { text: THINKING_FALLBACK, usage: null, success: false };
 	}
 }
 

--- a/src/gemini/types.ts
+++ b/src/gemini/types.ts
@@ -16,6 +16,22 @@ export type GeminiUsage = {
 	totalTokens: number;
 };
 
+export function addGeminiUsage(
+	total: GeminiUsage | null,
+	usage: GeminiUsage | null,
+): GeminiUsage | null {
+	if (!usage) {
+		return total;
+	}
+	return {
+		promptTokens: (total?.promptTokens ?? 0) + usage.promptTokens,
+		cachedTokens: (total?.cachedTokens ?? 0) + usage.cachedTokens,
+		thoughtsTokens: (total?.thoughtsTokens ?? 0) + usage.thoughtsTokens,
+		candidatesTokens: (total?.candidatesTokens ?? 0) + usage.candidatesTokens,
+		totalTokens: (total?.totalTokens ?? 0) + usage.totalTokens,
+	};
+}
+
 export type GeminiStreamEvent =
 	| {
 			type: "thinking";

--- a/src/workflows/answerQuestionWorkflow.test.ts
+++ b/src/workflows/answerQuestionWorkflow.test.ts
@@ -123,7 +123,11 @@ describe("AnswerQuestionWorkflow Steps", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockDeduplicationStore.isMarked.mockResolvedValue(false);
-		mockThinkingSummarizer.summarize.mockResolvedValue("思考要約");
+		mockThinkingSummarizer.summarize.mockResolvedValue({
+			text: "思考要約",
+			usage: null,
+			success: true,
+		});
 		// Reset fetch mock
 		globalThis.fetch = vi.fn();
 	});
@@ -451,9 +455,11 @@ describe("AnswerQuestionWorkflow Steps", () => {
 		});
 
 		it("displays summarized thinking content with thought balloon", async () => {
-			mockThinkingSummarizer.summarize.mockResolvedValue(
-				"問題を多角的に分析中",
-			);
+			mockThinkingSummarizer.summarize.mockResolvedValue({
+				text: "問題を多角的に分析中",
+				usage: null,
+				success: true,
+			});
 			mockStream([
 				{ type: "thinking", delta: "private thought" },
 				{
@@ -481,12 +487,85 @@ describe("AnswerQuestionWorkflow Steps", () => {
 			expect(firstCall).toContain("問題を多角的に分析中");
 			expect(firstCall).not.toContain("```");
 			expect(mockThinkingSummarizer.summarize).toHaveBeenCalledWith(
+				"",
 				"private thought",
 			);
 			expect(result.response).toBe("final answer");
 			expect(result.updatedHistory).not.toContainEqual(
 				expect.objectContaining({ text: expect.stringContaining("private") }),
 			);
+		});
+
+		it("summarizes only new thinking and aggregates summary usage", async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(0);
+			const secondThought = "x".repeat(200);
+			mockThinkingSummarizer.summarize
+				.mockResolvedValueOnce({
+					text: "最初の要約",
+					usage: {
+						promptTokens: 10,
+						cachedTokens: 1,
+						thoughtsTokens: 0,
+						candidatesTokens: 2,
+						totalTokens: 12,
+					},
+					success: true,
+				})
+				.mockResolvedValueOnce({
+					text: "更新後の要約",
+					usage: {
+						promptTokens: 20,
+						cachedTokens: 2,
+						thoughtsTokens: 0,
+						candidatesTokens: 3,
+						totalTokens: 23,
+					},
+					success: true,
+				});
+			mockGeminiGateway.generateStream.mockImplementation(async function* () {
+				yield { type: "thinking", delta: "first thought" };
+				vi.setSystemTime(2000);
+				yield { type: "thinking", delta: secondThought };
+				yield {
+					type: "response",
+					delta: "answer",
+					accumulated: "answer",
+				};
+			});
+			mockDiscordInstance.editOriginalMessage.mockResolvedValue(true);
+
+			const result = await streamGeminiWithDiscordEditsStep(
+				mockEnv,
+				"token",
+				"question",
+				"message",
+				sheetData,
+				history,
+				mockLogger,
+			);
+
+			expect(mockThinkingSummarizer.summarize).toHaveBeenNthCalledWith(
+				1,
+				"",
+				"first thought",
+			);
+			expect(mockThinkingSummarizer.summarize).toHaveBeenNthCalledWith(
+				2,
+				"最初の要約",
+				secondThought,
+			);
+			expect(result).toMatchObject({
+				thinkingSummaryCallCount: 2,
+				thinkingSummarySuccessCount: 2,
+				thinkingSummaryUsage: {
+					promptTokens: 30,
+					cachedTokens: 3,
+					thoughtsTokens: 0,
+					candidatesTokens: 5,
+					totalTokens: 35,
+				},
+			});
 		});
 
 		it("forces Discord edit on phase transition from thinking to response", async () => {
@@ -585,7 +664,7 @@ describe("AnswerQuestionWorkflow Steps", () => {
 			);
 			expect(mockGeminiGateway.generateStream).toHaveBeenCalledWith(
 				expect.objectContaining({
-					model: "gemini-3.6-flash",
+					model: "gemini-3.5-flash-lite",
 					prompt: expect.objectContaining({
 						contents: [
 							{ role: "user", parts: [{ text: "previous" }] },

--- a/src/workflows/answerQuestionWorkflow.ts
+++ b/src/workflows/answerQuestionWorkflow.ts
@@ -23,6 +23,7 @@ import { createGeminiGateway } from "../gemini/gateway";
 import { buildAnswerPrompt } from "../gemini/promptBuilder";
 import { StreamCoordinator } from "../gemini/streamCoordinator";
 import { createThinkingSummarizer } from "../gemini/thinkingSummarizer";
+import { addGeminiUsage } from "../gemini/types";
 import { createConversationHistoryRepository } from "../repositories/conversationHistory";
 import { createDeduplicationStore } from "../repositories/deduplicationStore";
 import { createSheetCacheRepository } from "../repositories/sheetCache";
@@ -180,6 +181,13 @@ export async function streamGeminiWithDiscordEditsStep(
 	let editCount = 0;
 	let retryCount = 0;
 	let deliveryDurationMs = 0;
+	let thinkingSummary = "";
+	let summarizedThinkingLength = 0;
+	let thinkingSummaryUsage: StreamingGeminiOutput["thinkingSummaryUsage"] =
+		null;
+	let thinkingSummaryCallCount = 0;
+	let thinkingSummarySuccessCount = 0;
+	let thinkingSummaryDurationMs = 0;
 
 	log.info("Starting Gemini streaming with Discord edits");
 	for await (const event of gateway.generateStream({
@@ -191,10 +199,28 @@ export async function streamGeminiWithDiscordEditsStep(
 			continue;
 		}
 
-		const content =
-			decision.phase === "thinking"
-				? formatThinking(question, await summarizer.summarize(decision.text))
-				: formatAnswer(question, decision.text);
+		let content: string;
+		if (decision.phase === "thinking") {
+			const summaryStartTime = Date.now();
+			const summaryResult = await summarizer.summarize(
+				thinkingSummary,
+				decision.text.slice(summarizedThinkingLength),
+			);
+			thinkingSummaryDurationMs += Date.now() - summaryStartTime;
+			thinkingSummaryCallCount++;
+			thinkingSummaryUsage = addGeminiUsage(
+				thinkingSummaryUsage,
+				summaryResult.usage,
+			);
+			if (summaryResult.success) {
+				thinkingSummary = summaryResult.text;
+				summarizedThinkingLength = decision.textLength;
+				thinkingSummarySuccessCount++;
+			}
+			content = formatThinking(question, summaryResult.text);
+		} else {
+			content = formatAnswer(question, decision.text);
+		}
 		const deliveryStartTime = Date.now();
 		const result = await delivery.deliverPreview(content);
 		deliveryDurationMs += Date.now() - deliveryStartTime;
@@ -252,6 +278,10 @@ export async function streamGeminiWithDiscordEditsStep(
 			{ role: "model", text: response },
 		],
 		usage: streamResult.usage,
+		thinkingSummaryUsage,
+		thinkingSummaryCallCount,
+		thinkingSummarySuccessCount,
+		thinkingSummaryDurationMs,
 		editCount,
 		chunkCount: finalDelivery.chunkCount,
 		deliveryStatus: finalDelivery.status,
@@ -360,6 +390,7 @@ export class AnswerQuestionWorkflow extends WorkflowEntrypoint<
 		const { token, message, requestId, conversationKey } = event.payload;
 		const log = logger.withContext({ requestId, workflowId: event.instanceId });
 		const metrics = getMetricsClient(this.env, log);
+		const config = loadConfig(this.env);
 
 		log.info("Workflow started", { messageLength: message.length });
 		const workflowStartTime = Date.now();
@@ -445,6 +476,23 @@ export class AnswerQuestionWorkflow extends WorkflowEntrypoint<
 					success: geminiSuccess,
 					durationMs: Date.now() - geminiStartTime,
 					usage: geminiUsage,
+					model: config.geminiModel,
+					purpose: "answer",
+					callCount: 1,
+				});
+			}
+
+			if (streamResult.thinkingSummaryCallCount > 0) {
+				metrics.recordGeminiCall({
+					requestId,
+					success:
+						streamResult.thinkingSummarySuccessCount ===
+						streamResult.thinkingSummaryCallCount,
+					durationMs: streamResult.thinkingSummaryDurationMs,
+					usage: streamResult.thinkingSummaryUsage,
+					model: config.geminiSummaryModel,
+					purpose: "thinking_summary",
+					callCount: streamResult.thinkingSummaryCallCount,
 				});
 			}
 

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -19,6 +19,10 @@ export interface StreamingGeminiOutput {
 	response: string;
 	updatedHistory: HistoryEntry[];
 	usage: GeminiUsage | null;
+	thinkingSummaryUsage: GeminiUsage | null;
+	thinkingSummaryCallCount: number;
+	thinkingSummarySuccessCount: number;
+	thinkingSummaryDurationMs: number;
 	editCount: number;
 	chunkCount: number;
 	deliveryStatus: DeliveryStatus;


### PR DESCRIPTION
## What changed

- switch the default answer model from Gemini 3.6 Flash to Gemini 3.5 Flash-Lite
- use minimal thinking while preserving the 8,192-token output limit and thought display
- summarize only newly emitted thinking plus the previous summary instead of repeatedly sending the full accumulated thought
- record answer and thinking-summary model usage separately, including model, purpose, token totals, and call count

## Why

The answer model and repeated full-thought summarization were driving unnecessary Gemini spend. This keeps the existing Discord interaction contract while reducing both model unit cost and repeated input tokens.

## Verification

- `npm run verify`
- 24 test files passed
- 267 tests passed
- Wrangler deploy dry-run passed
