### PR TITLE
docs: sync CLAUDE.md after PR #393

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,16 +8,67 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 npm run dev          # Local development with hot reload
 npm run deploy       # Deploy to Cloudflare Workers (with minification)
 npm test             # Run tests with Vitest
+npm run test:watch   # Run Vitest in watch mode
 npm run register     # Register Discord slash commands via Discord API
+npm run lint         # Run Biome linter only
+npm run format       # Run Biome formatter with auto-fix
 npm run check        # Run Biome formatter + linter with auto-fix
 npm run check:ci     # Run Biome check without writing (for CI)
 npm run typecheck    # Run TypeScript type checking without emitting files
+npm run cf-typegen   # Regenerate Cloudflare binding types (worker-configuration.d.ts)
 npm run verify       # Run all non-writing checks, tests, and a deploy dry-run
 ```
 
 ## Architecture
 
-Discord bot on Cloudflare Workers. Uses Google Gemini AI with a Google Sheets knowledge base. Cron health check (every 5 min) reports failures as GitHub Issues.
+Discord bot on Cloudflare Workers. Uses Google Gemini AI with a Google Sheets knowledge base, Cloudflare KV for caches and conversation history, and Analytics Engine for metrics.
+
+### Request flow
+
+1. Discord POSTs an interaction to `/`. `verifyDiscordInteraction` middleware checks the Ed25519 signature.
+2. `src/index.ts` (Hono) handles the interaction: `PING` → `PONG`; `APPLICATION_COMMAND` → validate config, parse the `/ask` command, start `ANSWER_QUESTION_WORKFLOW`, and immediately return a deferred response (Discord's 3-second limit).
+3. `AnswerQuestionWorkflow` (`src/workflows/answerQuestionWorkflow.ts`) runs the answer asynchronously as `step.do()` steps:
+   - `getSheetData` - KV cache, falling back to the Google Sheets API
+   - `getHistory` - conversation history from KV
+   - `streamGeminiAndEditDiscord` - stream the Gemini answer while progressively editing the Discord message (`retries.limit: 0`, `timeout: 120 seconds`)
+   - `saveHistory` - persist the updated history to KV
+4. `StreamCoordinator` throttles Discord edits (response: 1500 ms / 50 chars, thinking: 1000 ms / 200 chars). During the thinking phase, `ThinkingSummarizer` condenses thoughts into a one-line Japanese summary using the cheaper `GEMINI_SUMMARY_MODEL`; each call passes only the newly streamed thinking text plus the previous summary, so cost stays flat as thoughts grow.
+5. On failure, the workflow posts a user-facing error to Discord and files a GitHub Issue (deduplicated by an error fingerprint via KV, then a GitHub Issues search).
+
+Every stage records Analytics Engine metrics (Gemini calls tagged with model, `purpose` of `answer` or `thinking_summary`, and call count; KV cache hits; Sheets API calls; Discord webhook delivery; workflow completion). Metrics degrade to a no-op when the `METRICS` binding is absent.
+
+### Caching strategy (KV namespace `sushanshan_bot`)
+
+- `sheet_info:v2:<sha256 of spreadsheet config>` - sheet data, 5-minute TTL. The key is derived from the spreadsheet ID and sheet names, so config changes invalidate it automatically. Cache writes are best-effort.
+- `chat_history:v2:<conversationKey>` - conversation history, `HISTORY_TTL_SECONDS` TTL, capped at 20 entries and 64 KB (oldest entries dropped first).
+- `error_reported:<fingerprint>` - GitHub Issue deduplication marker, 1-hour TTL.
+
+### Scheduled health check
+
+Cron (every 5 min, `wrangler.toml` `[triggers]`) runs `src/health.ts`, which probes KV, the Gemini API, and the Google service account, and reports failures as GitHub Issues using the same deduplication.
+
+## Project Structure
+
+```
+src/
+  index.ts                  # Hono worker entry: Discord interactions, cron, Workflow re-export
+  config.ts                 # Bindings → AppConfig, defaults, validation (ConfigError)
+  contracts.ts              # Dependency-free shared types (Bindings, WorkflowParams, HistoryEntry)
+  health.ts                 # Scheduled health check (KV / Gemini / Google SA)
+  clients/                  # External services: discord, github, metrics, spreadSheet
+  discord/                  # Interaction parsing, message formatting, chunked delivery
+  gemini/                   # gateway, promptBuilder, streamCoordinator, thinkingSummarizer, types
+  middleware/               # verifyDiscordInteraction (Ed25519 signature verification)
+  repositories/             # KV-backed: sheetCache, conversationHistory, deduplicationStore
+  responses/                # errorResponse
+  utils/                    # compactSheet, errors, logger, requestId, retry
+  workflows/                # answerQuestionWorkflow, types
+scripts/                    # register.js, commands.js (Discord slash command registration)
+wrangler.toml               # Worker config: KV, Analytics Engine, Workflow, cron triggers
+worker-configuration.d.ts   # Generated Cloudflare types (npm run cf-typegen)
+```
+
+Tests live next to their sources as `*.test.ts` and run on `@cloudflare/vitest-pool-workers`.
 
 ## Environment Variables
 
@@ -28,12 +79,21 @@ Required in Cloudflare Workers secrets or `.dev.vars` for local development:
 - `GOOGLE_SERVICE_ACCOUNT` - Google Service Account credentials (JSON string)
 - `GITHUB_TOKEN` (optional) - GitHub PAT for auto-reporting errors and health check failures as Issues
 
-Optional runtime configuration (current production values are used when omitted):
+Optional runtime configuration (defaults in `DEFAULT_RUNTIME_CONFIG` in `src/config.ts` are used when omitted):
 
-- `GEMINI_MODEL`, `GEMINI_SUMMARY_MODEL` - Answer and thinking-summary models
+- `GEMINI_MODEL` - Answer model (default: `gemini-3.5-flash-lite`)
+- `GEMINI_SUMMARY_MODEL` - Thinking-summary model (default: `gemini-2.5-flash-lite`)
 - `GOOGLE_SPREADSHEET_ID`, `GOOGLE_DATA_SHEET_NAME`, `GOOGLE_DESCRIPTION_SHEET_NAME` - Google Sheets source
-- `GITHUB_REPOSITORY` - Error-report destination in `owner/repository` format
+- `GITHUB_REPOSITORY` - Error-report destination in `owner/repository` format (default: `henzai/yangbingyibot`)
 - `HISTORY_TTL_SECONDS` - Conversation history TTL (60–86400 seconds, default: 300)
+
+## Cloudflare Bindings
+
+Declared in `wrangler.toml` and typed in `Bindings` (`src/contracts.ts`):
+
+- `sushanshan_bot` (KV namespace) - sheet cache, conversation history, deduplication markers
+- `ANSWER_QUESTION_WORKFLOW` (Workflow, class `AnswerQuestionWorkflow`) - asynchronous answer pipeline
+- `METRICS` (Analytics Engine dataset `yangbingyibot_metrics`, optional) - falls back to `NoOpMetricsClient` when unbound
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary

CLAUDE.md の内容を PR #393 (Reduce Gemini inference cost) のマージ後の実コードと同期します。

## Changes

### Architecture (大幅に加筆)

- リクエストフローを追記: Discord 署名検証 → Hono ワーカー → deferred response → `ANSWER_QUESTION_WORKFLOW` の 4 ステップ (`getSheetData` / `getHistory` / `streamGeminiAndEditDiscord` / `saveHistory`)
- `StreamCoordinator` の Discord 編集スロットリング値 (response: 1500ms/50文字, thinking: 1000ms/200文字) を明記
- PR #393 の変更を反映: thinking 要約が「前回の要約 + 新規思考分のみ」を渡す差分方式になった点を記載
- Analytics Engine メトリクスを追記。PR #393 で追加された `model` / `purpose` (`answer` | `thinking_summary`) / `callCount` のタグを明記し、`METRICS` 未バインド時は `NoOpMetricsClient` にフォールバックすることを記載
- キャッシュ戦略のセクションを新設: `sheet_info:v2:` (5分 TTL、スプレッドシート設定の SHA-256 をキーに含む)、`chat_history:v2:` (最大 20 件 / 64KB)、`error_reported:` (1時間 TTL)
- GitHub Issue の 2 層重複排除 (KV → GitHub Issues 検索) を記載
- cron ヘルスチェックが KV / Gemini / Google Service Account を検査することを明記

### Project Structure (新設)

- `src/` 配下のディレクトリ構成 (`clients` / `discord` / `gemini` / `middleware` / `repositories` / `responses` / `utils` / `workflows`)、`scripts/`、`wrangler.toml`、`worker-configuration.d.ts` を追加
- テストがソース隣接の `*.test.ts` で `@cloudflare/vitest-pool-workers` 上で動くことを記載

### Environment Variables

- `GEMINI_MODEL` / `GEMINI_SUMMARY_MODEL` を分離し、デフォルト値を明記。PR #393 でデフォルトが `gemini-3.6-flash` → `gemini-3.5-flash-lite` に変更された点を反映
- `GITHUB_REPOSITORY` のデフォルト値 (`henzai/yangbingyibot`) を追記
- 「current production values」という曖昧な表現を `src/config.ts` の `DEFAULT_RUNTIME_CONFIG` への参照に置き換え

### Cloudflare Bindings (新設)

- 従来未記載だった `sushanshan_bot` (KV)、`ANSWER_QUESTION_WORKFLOW` (Workflow)、`METRICS` (Analytics Engine, optional) を wrangler.toml / `src/contracts.ts` に基づいて追加

### Development Commands

- package.json に存在するが未記載だった `test:watch` / `lint` / `format` / `cf-typegen` を追加 (既存の記載内容は package.json と一致しており変更なし)

---
Auto-generated by docs-sync workflow.
