### PR TITLE
fix(gemini): 空応答の終了理由をログとユーザー向けメッセージに配線

### DIFF
--- a/src/gemini/gateway.test.ts
+++ b/src/gemini/gateway.test.ts
@@ -139,7 +139,68 @@ describe("GeminiGateway", () => {
 					totalTokens: 130,
 				},
 			},
+			{ type: "finish", finishReason: undefined, blockReason: undefined },
 		]);
+	});
+
+	it("emits the finish reason and block reason reported by the stream", async () => {
+		mockGenerateContentStream.mockResolvedValue(
+			(async function* () {
+				yield {
+					candidates: [
+						{ content: { parts: [{ text: "thought", thought: true }] } },
+					],
+				};
+				yield {
+					candidates: [{ finishReason: "MAX_TOKENS" }],
+					promptFeedback: { blockReason: "SAFETY" },
+				};
+			})(),
+		);
+		const log = makeLogger();
+
+		const events = await collect(
+			new GeminiGateway("key", log).generateStream({ model: "model", prompt }),
+		);
+
+		expect(events.at(-1)).toEqual({
+			type: "finish",
+			finishReason: "MAX_TOKENS",
+			blockReason: "SAFETY",
+		});
+		expect(log.info).toHaveBeenCalledWith(
+			"Gemini streaming API completed",
+			expect.objectContaining({
+				finishReason: "MAX_TOKENS",
+				blockReason: "SAFETY",
+			}),
+		);
+	});
+
+	it("keeps the last reported finish reason instead of a later undefined one", async () => {
+		mockGenerateContentStream.mockResolvedValue(
+			(async function* () {
+				yield {
+					candidates: [
+						{
+							content: { parts: [{ text: "answer" }] },
+							finishReason: "STOP",
+						},
+					],
+				};
+				yield { candidates: [{ content: { parts: [] } }] };
+			})(),
+		);
+
+		const events = await collect(
+			new GeminiGateway("key").generateStream({ model: "model", prompt }),
+		);
+
+		expect(events.at(-1)).toEqual({
+			type: "finish",
+			finishReason: "STOP",
+			blockReason: undefined,
+		});
 	});
 
 	it("normalizes an error raised while consuming the stream", async () => {
@@ -277,7 +338,10 @@ describe("GeminiGateway", () => {
 			new GeminiGateway("key", log).generateStream({ model: "model", prompt }),
 		);
 
-		expect(events).toHaveLength(1);
+		expect(events).toEqual([
+			{ type: "response", delta: "answer", accumulated: "answer" },
+			{ type: "finish", finishReason: undefined, blockReason: undefined },
+		]);
 		expect(log.warn).toHaveBeenCalledWith("Gemini usage metadata missing", {
 			mode: "stream",
 		});

--- a/src/gemini/gateway.ts
+++ b/src/gemini/gateway.ts
@@ -131,11 +131,21 @@ export class GeminiGateway implements IGeminiGateway {
 
 		let accumulated = "";
 		let latestUsage: GeminiUsage | null = null;
+		let finishReason: string | undefined;
+		let blockReason: string | undefined;
 		try {
 			for await (const chunk of stream) {
 				const usage = toUsage(chunk.usageMetadata);
 				if (usage) {
 					latestUsage = usage;
+				}
+				const chunkFinishReason = chunk.candidates?.[0]?.finishReason;
+				if (chunkFinishReason !== undefined) {
+					finishReason = chunkFinishReason;
+				}
+				const chunkBlockReason = chunk.promptFeedback?.blockReason;
+				if (chunkBlockReason !== undefined) {
+					blockReason = chunkBlockReason;
 				}
 
 				for (const part of chunk.candidates?.[0]?.content?.parts ?? []) {
@@ -163,9 +173,12 @@ export class GeminiGateway implements IGeminiGateway {
 		} else {
 			this.log.warn("Gemini usage metadata missing", { mode: "stream" });
 		}
+		yield { type: "finish", finishReason, blockReason };
 		this.log.info("Gemini streaming API completed", {
 			model: request.model,
 			durationMs: Date.now() - startTime,
+			finishReason,
+			blockReason,
 		});
 	}
 

--- a/src/gemini/streamCoordinator.test.ts
+++ b/src/gemini/streamCoordinator.test.ts
@@ -125,4 +125,46 @@ describe("StreamCoordinator", () => {
 			usage: { totalTokens: 17 },
 		});
 	});
+
+	it("records the finish reason without emitting a preview update", () => {
+		const coordinator = new StreamCoordinator(config);
+		coordinator.handle({ type: "thinking", delta: "thought only" }, 0);
+
+		expect(
+			coordinator.handle({ type: "finish", finishReason: "MAX_TOKENS" }, 1000),
+		).toBeNull();
+		expect(coordinator.getResult()).toMatchObject({
+			phase: "thinking",
+			response: "",
+			finishReason: "MAX_TOKENS",
+			blockReason: undefined,
+		});
+	});
+
+	it("records a prompt block reason from the finish event", () => {
+		const coordinator = new StreamCoordinator(config);
+
+		expect(
+			coordinator.handle(
+				{ type: "finish", finishReason: "SAFETY", blockReason: "SAFETY" },
+				0,
+			),
+		).toBeNull();
+		expect(coordinator.getResult()).toMatchObject({
+			finishReason: "SAFETY",
+			blockReason: "SAFETY",
+		});
+	});
+
+	it("leaves both reasons undefined when the stream finishes without them", () => {
+		const coordinator = new StreamCoordinator(config);
+		coordinator.handle({ type: "response", delta: "hi", accumulated: "hi" }, 0);
+		coordinator.handle({ type: "finish" }, 1);
+
+		expect(coordinator.getResult()).toMatchObject({
+			response: "hi",
+			finishReason: undefined,
+			blockReason: undefined,
+		});
+	});
 });

--- a/src/gemini/streamCoordinator.ts
+++ b/src/gemini/streamCoordinator.ts
@@ -29,6 +29,8 @@ export class StreamCoordinator {
 	private hasSeenThinking = false;
 	private response = "";
 	private usage: GeminiUsage | null = null;
+	private finishReason: string | undefined;
+	private blockReason: string | undefined;
 	private lastEditAt = 0;
 	private lastThinkingEditLength = 0;
 	private lastResponseEditLength = 0;
@@ -41,6 +43,12 @@ export class StreamCoordinator {
 	handle(event: GeminiStreamEvent, now: number): StreamPreviewDecision | null {
 		if (event.type === "usage") {
 			this.usage = event.usage;
+			return null;
+		}
+
+		if (event.type === "finish") {
+			this.finishReason = event.finishReason;
+			this.blockReason = event.blockReason;
 			return null;
 		}
 
@@ -115,12 +123,16 @@ export class StreamCoordinator {
 		response: string;
 		thinking: string;
 		usage: GeminiUsage | null;
+		finishReason: string | undefined;
+		blockReason: string | undefined;
 	} {
 		return {
 			phase: this.phase,
 			response: this.response,
 			thinking: this.thinking,
 			usage: this.usage,
+			finishReason: this.finishReason,
+			blockReason: this.blockReason,
 		};
 	}
 }

--- a/src/gemini/types.ts
+++ b/src/gemini/types.ts
@@ -45,6 +45,11 @@ export type GeminiStreamEvent =
 	| {
 			type: "usage";
 			usage: GeminiUsage;
+	  }
+	| {
+			type: "finish";
+			finishReason?: string;
+			blockReason?: string;
 	  };
 
 export type GeminiStreamRequest = {

--- a/src/workflows/answerQuestionWorkflow.test.ts
+++ b/src/workflows/answerQuestionWorkflow.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Bindings, HistoryEntry } from "../contracts";
 import { formatAnswer } from "../discord/formatter";
+import type { GeminiStreamEvent } from "../gemini/types";
 import { ExternalServiceError } from "../utils/errors";
 import type { Logger } from "../utils/logger";
 import type { HistoryOutput, SheetDataOutput } from "./types";
@@ -321,26 +322,7 @@ describe("AnswerQuestionWorkflow Steps", () => {
 		};
 		const history: HistoryOutput = { history: [] };
 
-		const mockStream = (
-			events: Array<
-				| { type: "thinking"; delta: string }
-				| {
-						type: "response";
-						delta: string;
-						accumulated: string;
-				  }
-				| {
-						type: "usage";
-						usage: {
-							promptTokens: number;
-							cachedTokens: number;
-							thoughtsTokens: number;
-							candidatesTokens: number;
-							totalTokens: number;
-						};
-				  }
-			>,
-		) => {
+		const mockStream = (events: GeminiStreamEvent[]) => {
 			mockGeminiGateway.generateStream.mockImplementation(async function* () {
 				for (const event of events) {
 					yield event;
@@ -452,6 +434,133 @@ describe("AnswerQuestionWorkflow Steps", () => {
 			});
 
 			expect(mockDiscordInstance.postMessage).not.toHaveBeenCalled();
+		});
+
+		it("logs the finish reason and token budget when the answer is empty", async () => {
+			mockStream([
+				{ type: "thinking", delta: "thought only" },
+				{
+					type: "usage",
+					usage: {
+						promptTokens: 100,
+						cachedTokens: 0,
+						thoughtsTokens: 8192,
+						candidatesTokens: 0,
+						totalTokens: 8292,
+					},
+				},
+				{ type: "finish", finishReason: "MAX_TOKENS" },
+			]);
+			mockDiscordInstance.editOriginalMessage.mockResolvedValue(undefined);
+
+			await expect(
+				streamGeminiWithDiscordEditsStep(
+					mockEnv,
+					"token",
+					"question",
+					"message",
+					sheetData,
+					history,
+					mockLogger,
+				),
+			).rejects.toThrow();
+
+			expect(mockLogger.error).toHaveBeenCalledWith(
+				"Gemini returned an empty answer",
+				{
+					finishReason: "MAX_TOKENS",
+					blockReason: undefined,
+					thinkingLength: "thought only".length,
+					thoughtsTokens: 8192,
+				},
+			);
+		});
+
+		it("explains a token-budget exhaustion to the user", async () => {
+			mockStream([
+				{ type: "thinking", delta: "thought only" },
+				{ type: "finish", finishReason: "MAX_TOKENS" },
+			]);
+			mockDiscordInstance.editOriginalMessage.mockResolvedValue(undefined);
+
+			await expect(
+				streamGeminiWithDiscordEditsStep(
+					mockEnv,
+					"token",
+					"question",
+					"message",
+					sheetData,
+					history,
+					mockLogger,
+				),
+			).rejects.toMatchObject({
+				service: "gemini",
+				operation: "validate streamed response",
+				retryable: false,
+				userMessage:
+					"思考が長くなりすぎて回答を生成できませんでした。質問を短く区切って再度お試しください。",
+			});
+		});
+
+		it.each(["SAFETY", "RECITATION", "PROHIBITED_CONTENT"])(
+			"explains a %s finish reason as a safety block",
+			async (finishReason) => {
+				mockStream([{ type: "finish", finishReason }]);
+
+				await expect(
+					streamGeminiWithDiscordEditsStep(
+						mockEnv,
+						"token",
+						"question",
+						"message",
+						sheetData,
+						history,
+						mockLogger,
+					),
+				).rejects.toMatchObject({
+					userMessage: "安全性フィルタにより回答できませんでした。",
+				});
+			},
+		);
+
+		it("explains a prompt-level block reason as a safety block", async () => {
+			mockStream([{ type: "finish", blockReason: "SAFETY" }]);
+
+			await expect(
+				streamGeminiWithDiscordEditsStep(
+					mockEnv,
+					"token",
+					"question",
+					"message",
+					sheetData,
+					history,
+					mockLogger,
+				),
+			).rejects.toMatchObject({
+				userMessage: "安全性フィルタにより回答できませんでした。",
+			});
+		});
+
+		it("keeps the generic message when no finish reason explains the empty answer", async () => {
+			mockStream([
+				{ type: "thinking", delta: "thought only" },
+				{ type: "finish", finishReason: "STOP" },
+			]);
+			mockDiscordInstance.editOriginalMessage.mockResolvedValue(undefined);
+
+			await expect(
+				streamGeminiWithDiscordEditsStep(
+					mockEnv,
+					"token",
+					"question",
+					"message",
+					sheetData,
+					history,
+					mockLogger,
+				),
+			).rejects.toMatchObject({
+				userMessage: "AIから有効な応答が得られませんでした。",
+			});
 		});
 
 		it("displays summarized thinking content with thought balloon", async () => {

--- a/src/workflows/answerQuestionWorkflow.ts
+++ b/src/workflows/answerQuestionWorkflow.ts
@@ -53,6 +53,31 @@ function getMetricsClient(env: Bindings, log: Logger): IMetricsClient {
 	return new NoOpMetricsClient();
 }
 
+const BLOCKED_FINISH_REASONS = new Set([
+	"SAFETY",
+	"RECITATION",
+	"PROHIBITED_CONTENT",
+]);
+
+/**
+ * Explain an empty Gemini answer to the user based on why the stream finished.
+ */
+function emptyResponseUserMessage(
+	finishReason: string | undefined,
+	blockReason: string | undefined,
+): string {
+	if (finishReason === "MAX_TOKENS") {
+		return "思考が長くなりすぎて回答を生成できませんでした。質問を短く区切って再度お試しください。";
+	}
+	if (
+		blockReason ||
+		(finishReason && BLOCKED_FINISH_REASONS.has(finishReason))
+	) {
+		return "安全性フィルタにより回答できませんでした。";
+	}
+	return "AIから有効な応答が得られませんでした。";
+}
+
 // Step 1: Get sheet data from KV cache or Google Sheets
 export async function getSheetDataStep(
 	env: Bindings,
@@ -246,11 +271,18 @@ export async function streamGeminiWithDiscordEditsStep(
 	const streamResult = coordinator.getResult();
 	const response = streamResult.response;
 	if (!response.trim()) {
+		const { finishReason, blockReason } = streamResult;
+		log.error("Gemini returned an empty answer", {
+			finishReason,
+			blockReason,
+			thinkingLength: streamResult.thinking.length,
+			thoughtsTokens: streamResult.usage?.thoughtsTokens,
+		});
 		throw new ExternalServiceError({
 			service: "gemini",
 			operation: "validate streamed response",
 			retryable: false,
-			userMessage: "AIから有効な応答が得られませんでした。",
+			userMessage: emptyResponseUserMessage(finishReason, blockReason),
 		});
 	}
 


### PR DESCRIPTION
Fixes #398

## 概要

Gemini のストリームが thought 以外のテキストを 1 文字も返さなかった際に、原因（トークン上限 / セーフティブロック / その他）が事後に切り分けられるよう、終了理由を配線してログとユーザー向けメッセージに反映しました。

`maxOutputTokens` などの生成パラメータは**変更していません**（先に実データを取るのが目的のため、本 issue のスコープ外）。

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/gemini/types.ts` | `GeminiStreamEvent` に `{ type: "finish"; finishReason?: string; blockReason?: string }` を追加 |
| `src/gemini/gateway.ts` | チャンク走査中に `candidates[0].finishReason` / `promptFeedback.blockReason` を後勝ちで保持（`undefined` では上書きしない）。ストリーム終了後に `finish` イベントを yield し、完了ログにも両者を含める |
| `src/gemini/streamCoordinator.ts` | `handle()` が `finish` を保持して `null` を返す（プレビュー更新なし）。`getResult()` が `finishReason` / `blockReason` を返す |
| `src/workflows/answerQuestionWorkflow.ts` | 空応答分岐で `log.error("Gemini returned an empty answer", { finishReason, blockReason, thinkingLength, thoughtsTokens })` を出力し、`userMessage` を原因別に出し分け |

正常系（`response` / `thinking` の yield 順序、`service` / `operation` / `retryable: false`）は変更していません。

### ユーザー向けメッセージの出し分け

- `finishReason === "MAX_TOKENS"` → `思考が長くなりすぎて回答を生成できませんでした。質問を短く区切って再度お試しください。`
- `blockReason` あり、または `finishReason` が `SAFETY` / `RECITATION` / `PROHIBITED_CONTENT` → `安全性フィルタにより回答できませんでした。`
- それ以外 → 現行の `AIから有効な応答が得られませんでした。`

## テスト

- `gateway.test.ts`: `finish` イベントが `finishReason` / `blockReason` 付きで yield されること、後勝ち保持で後続の `undefined` に上書きされないこと、完了ログに含まれることを追加検証。既存の `toEqual` / 件数アサーションを `finish` イベント込みに更新
- `streamCoordinator.test.ts`: `finish` が `null` を返し `getResult()` に反映されること（`finishReason` のみ / `blockReason` 併用 / 両方なし）を追加
- `answerQuestionWorkflow.test.ts`: 既存テスト「rejects an empty Gemini answer before persisting history」は維持。`MAX_TOKENS` / セーフティ 3 種 / `blockReason` / その他（`STOP`）の `userMessage` 出し分けと、`log.error` の出力内容を追加検証。`mockStream` の引数型を `GeminiStreamEvent[]` に整理

## 検証状況

実行環境で `npm install` / `npx` がネットワーク制限によりブロックされ、`node_modules` が存在しないため、ローカルでの `npm run check` / `npm test` / `npm run typecheck` は実行できませんでした。代わりに CI で検証済みです:

| ジョブ | 結果 |
|---|---|
| `test` (`npm test`) | ✅ pass (33s) |
| `typecheck` (`npm run typecheck`) | ✅ pass (19s) |
| `lint` (`npm run check:ci`) | ✅ pass (23s) |
| `build` (wrangler deploy --dry-run) | ✅ pass (14s) |

Generated with [Claude Code](https://claude.ai/code)
