### PR TITLE
chore: strengthen Renovate automation

### DIFF
--- a/.github/workflows/renovate-autofix.yml
+++ b/.github/workflows/renovate-autofix.yml
@@ -123,3 +123,102 @@ jobs:
               issue_number: prNumber,
               body: body,
             });
+
+  automerge-autofixed:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    concurrency:
+      group: renovate-autofix-merge-main
+      cancel-in-progress: false
+    steps:
+      - name: Merge successfully auto-fixed Renovate PR
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            const run = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+            });
+
+            const pullRequests = run.data.pull_requests;
+            if (!pullRequests || pullRequests.length === 0) {
+              console.log('No PRs associated with this workflow run');
+              return;
+            }
+
+            const prNumber = pullRequests[0].number;
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            if (pr.data.state !== 'open') {
+              console.log(`PR #${prNumber} is no longer open`);
+              return;
+            }
+
+            const expectedRepo = `${context.repo.owner}/${context.repo.repo}`;
+            const labels = pr.data.labels.map((label) => label.name);
+            const isRenovate = pr.data.user.login === 'renovate[bot]'
+              && pr.data.head.ref.startsWith('renovate/')
+              && pr.data.head.repo?.full_name === expectedRepo;
+            const wasAutoFixed = labels.includes('auto-fix-attempted');
+            const isAutomergeEnabled = pr.data.body?.includes(
+              '**Automerge**: Enabled.',
+            );
+            const headMatches = pr.data.head.sha === run.data.head_sha;
+
+            if (!isRenovate || !wasAutoFixed || !isAutomergeEnabled || !headMatches) {
+              console.log(`PR #${prNumber} does not meet auto-merge conditions`, {
+                isRenovate,
+                wasAutoFixed,
+                isAutomergeEnabled,
+                headMatches,
+              });
+              return;
+            }
+
+            const comparison = await github.rest.repos.compareCommitsWithBasehead({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              basehead: `${pr.data.base.sha}...${pr.data.head.sha}`,
+            });
+            if (comparison.data.behind_by !== 0) {
+              console.log(`PR #${prNumber} is behind its base branch; skipping`);
+              return;
+            }
+
+            let result;
+            try {
+              result = await github.rest.pulls.merge({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                sha: pr.data.head.sha,
+                merge_method: 'squash',
+              });
+            } catch (error) {
+              const latest = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              if (latest.data.merged) {
+                console.log(`PR #${prNumber} was already auto-merged`);
+                return;
+              }
+              throw error;
+            }
+            if (!result.data.merged) {
+              core.setFailed(`PR #${prNumber} was not merged: ${result.data.message}`);
+              return;
+            }
+
+            console.log(`Squash-merged auto-fixed Renovate PR #${prNumber}`);

--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,30 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:recommended", ":automergeMinor"],
+	"extends": ["config:recommended", ":automergeMinor", ":automergeDigest"],
+	"automergeType": "pr",
+	"platformAutomerge": true,
+	"automergeStrategy": "squash",
 	"packageRules": [
 		{
-			"groupName": "vitest",
+			"description": "Keep the Cloudflare and Vitest toolchain compatible",
+			"groupName": "Cloudflare and Vitest toolchain",
+			"groupSlug": "cloudflare-vitest",
+			"matchManagers": ["npm"],
 			"matchPackageNames": [
-				"/vitest/",
-				"/@vitest//",
-				"/@cloudflare/vitest-pool-workers/"
-			]
+				"vitest",
+				"@vitest/**",
+				"@cloudflare/vitest-pool-workers",
+				"wrangler"
+			],
+			"separateMajorMinor": false
+		},
+		{
+			"description": "Update official GitHub Actions together",
+			"groupName": "official GitHub Actions",
+			"groupSlug": "official-github-actions",
+			"matchManagers": ["github-actions"],
+			"matchPackageNames": ["actions/**"],
+			"separateMajorMinor": false
 		}
 	]
 }


### PR DESCRIPTION
## Summary

- make PR-based squash automerge explicit and add digest automerge
- group the coupled Cloudflare/Vitest toolchain and official GitHub Actions
- safely squash-merge auto-fixed Renovate PRs after the full CI workflow succeeds

## Why

Renovate already automerges most non-major updates, but related packages can arrive in separate PRs and a Claude-generated fix marks the Renovate branch as modified, preventing Renovate from finishing the merge. This keeps major updates manual while reducing routine dependency-update work.

The auto-fix completion path is restricted to open same-repository Renovate PRs that carry the `auto-fix-attempted` label, explicitly advertise `Automerge: Enabled`, match the successful workflow head SHA, and are not behind `main`.

## Validation

- `npm run verify` with Node.js 24.13.0
- 24 test files / 267 tests passed
- Wrangler deploy dry-run passed
- `renovate-config-validator renovate.json` passed
- workflow YAML parsed successfully

## Follow-up repository settings

After explicit action-time approval, enable GitHub Auto-merge and update the `main` ruleset so `test`, `build`, `typecheck`, and `lint` are all strict required checks.